### PR TITLE
fix(window): restore saved launcher position on cold start

### DIFF
--- a/src/settings_ui.rs
+++ b/src/settings_ui.rs
@@ -17,6 +17,7 @@ use slint::{ComponentHandle, ModelRc, SharedString, VecModel};
 use crate::QueryWindow;
 use crate::daemon::HotkeyRegistration;
 use crate::hotkey::{MOD_ALT, MOD_CONTROL, MOD_META, MOD_SHIFT, format_hotkey_spec, slint_flag_for_modifier};
+use crate::logging::LogErr;
 use crate::plugins::manifest::{Manifest, OptionDef, OptionKind};
 use crate::settings::{Settings, WindowPosition};
 use crate::ui::{PluginOption, PluginSlot};
@@ -64,22 +65,14 @@ struct Inner {
     /// `OnceLock` so the controller's already-wired callbacks see the
     /// registration as soon as the daemon installs it.
     hotkey_registration: OnceLock<Arc<HotkeyRegistration>>,
-    /// "Settings are dirty, please flush" channel feeding the dedicated
-    /// writer thread. Every mutator sends `()` here; the writer drains
-    /// all pending signals between disk writes so a burst of edits
-    /// collapses into a single `Settings::save()`. Holding the sender on
-    /// `Inner` means dropping the last `SettingsController` clone closes
-    /// the channel and lets the writer thread exit cleanly.
+    /// Mutators send `()` here; the writer thread drains the queue and
+    /// flushes once per burst.
     dirty_tx: mpsc::Sender<()>,
 }
 
 impl SettingsController {
-    /// Build a controller from the manifest scan + initial loaded settings.
-    ///
-    /// Spawns a dedicated writer thread that owns the dirty-signal receiver.
-    /// The writer keeps a `Weak` reference to `Inner` so its existence does
-    /// not extend the controller's lifetime; once the last clone is dropped,
-    /// the channel closes and the writer exits.
+    /// Build a controller and spawn the writer thread that drains the
+    /// dirty-signal channel.
     #[must_use]
     pub fn new(manifests: Vec<Manifest>, settings: Settings) -> Self {
         let (dirty_tx, dirty_rx) = mpsc::channel::<()>();
@@ -390,10 +383,7 @@ impl SettingsController {
         self.queue_persist();
     }
 
-    /// Record a new launcher window origin. The disk write is dispatched
-    /// to the writer thread via the dirty-signal channel, so the caller
-    /// (typically the Slint UI thread firing on dismiss) returns
-    /// immediately while the writer drains the queue in the background.
+    /// Record a new launcher window origin and queue a disk flush.
     ///
     /// # Panics
     ///
@@ -542,24 +532,15 @@ impl SettingsController {
         self.set_option(plugin, key, value);
     }
 
-    /// Send a "settings are dirty" signal to the writer thread.
-    /// Non-blocking; the writer drains all pending signals between disk
-    /// writes so a rapid burst of mutations collapses into one save.
     fn queue_persist(&self) {
-        // The only `Err` path is "receiver dropped", which only happens
-        // when the writer thread has already exited (panic, lock
-        // poisoning, or process tear-down). Nothing actionable here —
-        // we'd just be writing into a dropped channel — but log so a
-        // truly stuck writer is visible in the journal.
-        if self.inner.dirty_tx.send(()).is_err() {
-            tracing::debug!("settings: writer thread receiver gone; dirty signal dropped");
-        }
+        self.inner
+            .dirty_tx
+            .send(())
+            .log_debug("settings: writer thread receiver gone");
     }
 
-    /// Synchronously flush the current settings to disk, bypassing the
-    /// writer thread. For the single-shot exit path (where the writer
-    /// thread would race the process death) and for tests that want to
-    /// assert on-disk state immediately after a mutation.
+    /// Synchronously save settings to disk, bypassing the writer thread.
+    /// For tests that assert on-disk state right after a mutation.
     ///
     /// # Panics
     ///
@@ -567,25 +548,18 @@ impl SettingsController {
     /// [`Self::launcher_position`] for the rationale.
     pub fn flush(&self) {
         let settings = self.inner.settings.lock().expect("settings lock");
-
-        if let Err(err) = settings.save() {
-            tracing::warn!(%err, "settings: flush failed");
-        }
+        settings.save().log_warn("settings: flush failed");
     }
 }
 
-/// Drain dirty signals from `rx` and persist the current settings until
-/// the channel closes. The writer holds a `Weak` to `Inner` so its
-/// existence doesn't extend the controller's lifetime — once every
-/// `SettingsController` clone is dropped, `Inner` drops, the sender
-/// goes with it, and `recv()` returns `Err` so the loop exits.
+/// Block on the dirty-signal channel and flush after each burst. Exits
+/// when the last `SettingsController` clone drops the sender.
 fn spawn_writer_thread(weak_inner: Weak<Inner>, rx: mpsc::Receiver<()>) {
-    let result = thread::Builder::new()
+    let spawn_result = thread::Builder::new()
         .name("highbeam-settings-writer".into())
         .spawn(move || {
             while rx.recv().is_ok() {
-                // Coalesce any signals queued while we were about to wake
-                // up so a burst of edits collapses into one disk pass.
+                // Drain coalesced signals before each save.
                 while rx.try_recv().is_ok() {}
 
                 let Some(inner) = weak_inner.upgrade() else {
@@ -598,19 +572,12 @@ fn spawn_writer_thread(weak_inner: Weak<Inner>, rx: mpsc::Receiver<()>) {
                         break;
                     }
                 };
-                // Drop the Arc before the disk I/O so we don't extend
-                // Inner's lifetime across a potentially slow write.
                 drop(inner);
-
-                if let Err(err) = snapshot.save() {
-                    tracing::warn!(%err, "settings: writer-thread save failed");
-                }
+                snapshot.save().log_warn("settings: writer save failed");
             }
         });
 
-    if let Err(err) = result {
-        tracing::warn!(%err, "settings: writer thread spawn failed");
-    }
+    spawn_result.log_warn("settings: writer thread spawn failed");
 }
 
 fn option_row(

--- a/src/settings_ui.rs
+++ b/src/settings_ui.rs
@@ -215,8 +215,8 @@ impl SettingsController {
         let ctrl = self.clone();
         let weak = window.as_weak();
 
-        window.on_cycle_alt_action_modifier(move || {
-            ctrl.cycle_alt_action_modifier();
+        window.on_set_alt_action_modifier(move |value| {
+            ctrl.set_alt_action_modifier(value.as_str());
 
             if let Some(w) = weak.upgrade() {
                 ctrl.refresh_global(&w);
@@ -254,17 +254,10 @@ impl SettingsController {
         }
     }
 
-    fn cycle_alt_action_modifier(&self) {
+    fn set_alt_action_modifier(&self, value: &str) {
         {
             let mut settings = self.inner.settings.lock().expect("settings lock");
-            let current = settings.alt_action_modifier();
-            let idx = crate::settings::ALT_ACTION_MODIFIER_CHOICES
-                .iter()
-                .position(|c| *c == current)
-                .unwrap_or(0);
-            let next_idx = (idx + 1) % crate::settings::ALT_ACTION_MODIFIER_CHOICES.len();
-
-            settings.set_alt_action_modifier(crate::settings::ALT_ACTION_MODIFIER_CHOICES[next_idx]);
+            settings.set_alt_action_modifier(value);
         }
 
         if let Err(err) = self.persist() {
@@ -726,12 +719,11 @@ mod tests {
         assert!(!ctrl.alt_modifier_held(MOD_SHIFT));
         assert!(!ctrl.alt_modifier_held(0));
 
-        // Switching the setting via cycle reaches each choice in turn.
-        ctrl.cycle_alt_action_modifier(); // Alt -> Shift
+        ctrl.set_alt_action_modifier("Shift");
         assert!(ctrl.alt_modifier_held(MOD_SHIFT));
         assert!(!ctrl.alt_modifier_held(MOD_ALT));
 
-        ctrl.cycle_alt_action_modifier(); // Shift -> Cmd
+        ctrl.set_alt_action_modifier("Cmd");
         #[cfg(target_os = "macos")]
         {
             // Slint reports physical Cmd as `control` on macOS.
@@ -744,7 +736,7 @@ mod tests {
             assert!(!ctrl.alt_modifier_held(MOD_CONTROL));
         }
 
-        ctrl.cycle_alt_action_modifier(); // Cmd -> Ctrl
+        ctrl.set_alt_action_modifier("Ctrl");
         #[cfg(target_os = "macos")]
         {
             assert!(ctrl.alt_modifier_held(MOD_META));
@@ -756,7 +748,7 @@ mod tests {
             assert!(!ctrl.alt_modifier_held(MOD_META));
         }
 
-        ctrl.cycle_alt_action_modifier(); // Ctrl -> wraps back to Alt
+        ctrl.set_alt_action_modifier("Alt");
         assert!(ctrl.alt_modifier_held(MOD_ALT));
     }
 }

--- a/src/settings_ui.rs
+++ b/src/settings_ui.rs
@@ -7,7 +7,9 @@
 //! pipeline; the settings view talks to the same `QueryWindow` but its
 //! state is independent of the query/results state.
 
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::thread;
 
 use serde_json::Value as JsonValue;
 use slint::{ComponentHandle, ModelRc, SharedString, VecModel};
@@ -15,7 +17,6 @@ use slint::{ComponentHandle, ModelRc, SharedString, VecModel};
 use crate::QueryWindow;
 use crate::daemon::HotkeyRegistration;
 use crate::hotkey::{MOD_ALT, MOD_CONTROL, MOD_META, MOD_SHIFT, format_hotkey_spec, slint_flag_for_modifier};
-use crate::logging::LogErr;
 use crate::plugins::manifest::{Manifest, OptionDef, OptionKind};
 use crate::settings::{Settings, WindowPosition};
 use crate::ui::{PluginOption, PluginSlot};
@@ -63,19 +64,35 @@ struct Inner {
     /// `OnceLock` so the controller's already-wired callbacks see the
     /// registration as soon as the daemon installs it.
     hotkey_registration: OnceLock<Arc<HotkeyRegistration>>,
+    /// "Settings are dirty, please flush" channel feeding the dedicated
+    /// writer thread. Every mutator sends `()` here; the writer drains
+    /// all pending signals between disk writes so a burst of edits
+    /// collapses into a single `Settings::save()`. Holding the sender on
+    /// `Inner` means dropping the last `SettingsController` clone closes
+    /// the channel and lets the writer thread exit cleanly.
+    dirty_tx: mpsc::Sender<()>,
 }
 
 impl SettingsController {
     /// Build a controller from the manifest scan + initial loaded settings.
+    ///
+    /// Spawns a dedicated writer thread that owns the dirty-signal receiver.
+    /// The writer keeps a `Weak` reference to `Inner` so its existence does
+    /// not extend the controller's lifetime; once the last clone is dropped,
+    /// the channel closes and the writer exits.
     #[must_use]
     pub fn new(manifests: Vec<Manifest>, settings: Settings) -> Self {
-        Self {
-            inner: Arc::new(Inner {
-                manifests,
-                settings: Mutex::new(settings),
-                hotkey_registration: OnceLock::new(),
-            }),
-        }
+        let (dirty_tx, dirty_rx) = mpsc::channel::<()>();
+        let inner = Arc::new(Inner {
+            manifests,
+            settings: Mutex::new(settings),
+            hotkey_registration: OnceLock::new(),
+            dirty_tx,
+        });
+
+        spawn_writer_thread(Arc::downgrade(&inner), dirty_rx);
+
+        Self { inner }
     }
 
     /// Wire the live OS hotkey registration so capture / reset paths can
@@ -112,14 +129,13 @@ impl SettingsController {
             }
         });
 
-        let ctrl = self.clone();
         let weak = window.as_weak();
 
         window.on_close_settings(move || {
-            // Persist on close — the toggle/set callbacks also persist, but
-            // close acts as a final commit point if anything fell through.
+            // Each mutator already queued a dirty signal, so the writer
+            // thread will flush whatever's outstanding. Closing the view
+            // doesn't need its own write — the queued one is sufficient.
             if let Some(w) = weak.upgrade() {
-                ctrl.persist().log_warn("settings: persist on close failed");
                 w.set_current_view(0);
             }
         });
@@ -249,9 +265,7 @@ impl SettingsController {
             settings.set_hotkey(value);
         }
 
-        if let Err(err) = self.persist() {
-            tracing::warn!(%err, "settings: persist after hotkey-set failed");
-        }
+        self.queue_persist();
     }
 
     fn set_alt_action_modifier(&self, value: &str) {
@@ -260,9 +274,7 @@ impl SettingsController {
             settings.set_alt_action_modifier(value);
         }
 
-        if let Err(err) = self.persist() {
-            tracing::warn!(%err, "settings: persist after alt-action-modifier change failed");
-        }
+        self.queue_persist();
     }
 
     /// Last saved launcher window origin, or `None` if the user has never
@@ -366,24 +378,22 @@ impl SettingsController {
         if entries.is_empty() {
             return;
         }
-        let result = {
+
+        {
             let mut s = self.inner.settings.lock().expect("settings lock");
 
             for (name, version) in entries {
                 s.set_last_loaded_version(name, version.clone());
             }
-            s.save()
-        };
-
-        if let Err(err) = result {
-            tracing::warn!(%err, "settings: could not persist last_loaded_version after lifecycle dispatch");
         }
+
+        self.queue_persist();
     }
 
-    /// Record a new launcher window origin and flush to disk. Used by the
-    /// window layer after the user finishes a drag; persistence is best-
-    /// effort because losing the latest position is preferable to a
-    /// blocked hide path.
+    /// Record a new launcher window origin. The disk write is dispatched
+    /// to the writer thread via the dirty-signal channel, so the caller
+    /// (typically the Slint UI thread firing on dismiss) returns
+    /// immediately while the writer drains the queue in the background.
     ///
     /// # Panics
     ///
@@ -395,9 +405,7 @@ impl SettingsController {
             settings.set_launcher_position(position);
         }
 
-        if let Err(err) = self.persist() {
-            tracing::warn!(%err, "settings: persist after launcher-position-set failed");
-        }
+        self.queue_persist();
     }
 
     /// Forget the saved launcher position. The next show recenters via the
@@ -413,9 +421,7 @@ impl SettingsController {
             settings.clear_launcher_position();
         }
 
-        if let Err(err) = self.persist() {
-            tracing::warn!(%err, "settings: persist after launcher-position-clear failed");
-        }
+        self.queue_persist();
     }
 
     fn refresh_slots(&self, window: &QueryWindow) {
@@ -471,9 +477,7 @@ impl SettingsController {
             settings.set_plugin_enabled(plugin, enabled);
         }
 
-        if let Err(err) = self.persist() {
-            tracing::warn!(plugin, %err, "settings: persist after toggle failed");
-        }
+        self.queue_persist();
     }
 
     fn set_option(&self, plugin: &str, key: &str, value: JsonValue) {
@@ -482,9 +486,7 @@ impl SettingsController {
             settings.set_plugin_option(plugin, key, value);
         }
 
-        if let Err(err) = self.persist() {
-            tracing::warn!(plugin, key, %err, "settings: persist after option-set failed");
-        }
+        self.queue_persist();
     }
 
     /// String callback handles two kinds: actual `string` options (pass
@@ -540,9 +542,74 @@ impl SettingsController {
         self.set_option(plugin, key, value);
     }
 
-    fn persist(&self) -> std::io::Result<()> {
+    /// Send a "settings are dirty" signal to the writer thread.
+    /// Non-blocking; the writer drains all pending signals between disk
+    /// writes so a rapid burst of mutations collapses into one save.
+    fn queue_persist(&self) {
+        // The only `Err` path is "receiver dropped", which only happens
+        // when the writer thread has already exited (panic, lock
+        // poisoning, or process tear-down). Nothing actionable here —
+        // we'd just be writing into a dropped channel — but log so a
+        // truly stuck writer is visible in the journal.
+        if self.inner.dirty_tx.send(()).is_err() {
+            tracing::debug!("settings: writer thread receiver gone; dirty signal dropped");
+        }
+    }
+
+    /// Synchronously flush the current settings to disk, bypassing the
+    /// writer thread. For the single-shot exit path (where the writer
+    /// thread would race the process death) and for tests that want to
+    /// assert on-disk state immediately after a mutation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the settings mutex is poisoned. See
+    /// [`Self::launcher_position`] for the rationale.
+    pub fn flush(&self) {
         let settings = self.inner.settings.lock().expect("settings lock");
-        settings.save()
+
+        if let Err(err) = settings.save() {
+            tracing::warn!(%err, "settings: flush failed");
+        }
+    }
+}
+
+/// Drain dirty signals from `rx` and persist the current settings until
+/// the channel closes. The writer holds a `Weak` to `Inner` so its
+/// existence doesn't extend the controller's lifetime — once every
+/// `SettingsController` clone is dropped, `Inner` drops, the sender
+/// goes with it, and `recv()` returns `Err` so the loop exits.
+fn spawn_writer_thread(weak_inner: Weak<Inner>, rx: mpsc::Receiver<()>) {
+    let result = thread::Builder::new()
+        .name("highbeam-settings-writer".into())
+        .spawn(move || {
+            while rx.recv().is_ok() {
+                // Coalesce any signals queued while we were about to wake
+                // up so a burst of edits collapses into one disk pass.
+                while rx.try_recv().is_ok() {}
+
+                let Some(inner) = weak_inner.upgrade() else {
+                    break;
+                };
+                let snapshot = match inner.settings.lock() {
+                    Ok(g) => g.clone(),
+                    Err(err) => {
+                        tracing::error!(?err, "settings: writer saw poisoned lock");
+                        break;
+                    }
+                };
+                // Drop the Arc before the disk I/O so we don't extend
+                // Inner's lifetime across a potentially slow write.
+                drop(inner);
+
+                if let Err(err) = snapshot.save() {
+                    tracing::warn!(%err, "settings: writer-thread save failed");
+                }
+            }
+        });
+
+    if let Err(err) = result {
+        tracing::warn!(%err, "settings: writer thread spawn failed");
     }
 }
 
@@ -701,6 +768,10 @@ mod tests {
         let ctrl = SettingsController::new(manifests, settings);
 
         ctrl.set_option_for_kind("p", "limit", "999");
+        // Mutators queue an async write; flush synchronously so we can
+        // assert on the on-disk state without racing the writer thread.
+        ctrl.flush();
+
         let reloaded = Settings::load_from(&path);
         let opts = reloaded.plugin_options("p");
         assert_eq!(opts.get("limit"), Some(&JsonValue::Number(20.into())));

--- a/src/window.rs
+++ b/src/window.rs
@@ -316,6 +316,13 @@ pub(crate) fn hide_and_persist_position(window: &QueryWindow, settings: &Setting
 /// connected display. The off-screen check matters when the user unplugs
 /// the monitor the window was last positioned on — without it, the next
 /// show would put the window in the void.
+///
+/// On cold start the winit window hasn't been realised yet (Slint creates
+/// it in `about_to_wait` on the next event-loop tick), so `monitor_rects`
+/// returns empty and the off-screen check can't be made. In that case we
+/// seed the position into `WindowAttributes` via `slint::Window::set_position`
+/// — winit uses that as the new window's origin and validation runs the
+/// next time `show` fires with the winit window live.
 fn apply_saved_or_centered_position(window: &QueryWindow, settings: &SettingsController) {
     let Some(saved) = settings.launcher_position() else {
         center_on_focused_display(window);
@@ -323,6 +330,11 @@ fn apply_saved_or_centered_position(window: &QueryWindow, settings: &SettingsCon
     };
 
     let rects = monitor_rects(window);
+
+    if rects.is_empty() {
+        set_outer_position(window, saved);
+        return;
+    }
 
     if !position_visible_on_any_monitor(saved, &rects) {
         tracing::info!(
@@ -349,15 +361,13 @@ fn capture_outer_position(window: &QueryWindow) -> Option<WindowPosition> {
         .flatten()
 }
 
-/// Push the window's outer position via winit directly — `slint::Window::
-/// set_position` writes the inner/content position which on macOS differs
-/// from the outer `NSWindow` frame by the title bar height. We use the outer
-/// rect so a restored position lines up byte-identical with where the user
-/// dropped it.
+/// Push the window's outer position. `slint::Window::set_position` resolves
+/// to `winit::Window::set_outer_position` when the winit window is live, and
+/// to `WindowAttributes::position` (consumed at creation) when it isn't —
+/// so this works both for the live re-show path and for the cold-start path
+/// where Slint hasn't realised the winit window yet.
 fn set_outer_position(window: &QueryWindow, pos: WindowPosition) {
-    let _ = window.window().with_winit_window(|w: &winit::window::Window| {
-        w.set_outer_position(winit::dpi::PhysicalPosition::new(pos.x, pos.y));
-    });
+    window.window().set_position(slint::PhysicalPosition::new(pos.x, pos.y));
 }
 
 /// Kick off a native OS-driven window drag. winit's `drag_window()` blocks
@@ -705,9 +715,11 @@ mod tests {
 
     #[test]
     fn position_visible_requires_at_least_one_monitor() {
-        // No monitors known to winit (headless tests, backend not
-        // initialised) means we can't validate; the safe default is "treat
-        // as off-screen" so the host falls back to the centered path.
+        // No monitors in the slice means the pure check can't validate; the
+        // host short-circuits ahead of this call (`apply_saved_or_centered_position`
+        // treats empty rects as "winit window not yet realised, trust the
+        // saved value") so this branch fires only when monitors really are
+        // empty.
         let pos = WindowPosition { x: 100, y: 100 };
         assert!(!position_visible_on_any_monitor(pos, &[]));
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -307,23 +307,27 @@ pub(crate) fn hide_and_persist_position(window: &QueryWindow, settings: &Setting
 /// show would put the window in the void.
 ///
 /// On cold start the winit window hasn't been realised yet (Slint creates
-/// it in `about_to_wait` on the next event-loop tick), so `monitor_rects`
-/// returns empty and the off-screen check can't be made. In that case we
-/// seed the position into `WindowAttributes` via `slint::Window::set_position`
-/// — winit uses that as the new window's origin and validation runs the
-/// next time `show` fires with the winit window live.
+/// it in `about_to_wait` on the next event-loop tick), so we can't query
+/// monitors at all. In that case we seed the position into
+/// `WindowAttributes` via `slint::Window::set_position` — winit uses that
+/// as the new window's origin and the off-screen check runs the next time
+/// `show` fires with the winit window live. We distinguish "no winit yet"
+/// from "winit alive but `available_monitors()` is empty" (e.g. KVM
+/// mid-switch, lid closed during wake) so the latter still falls through
+/// to the recenter path and doesn't blindly trust a possibly-off-screen
+/// saved value.
 fn apply_saved_or_centered_position(window: &QueryWindow, settings: &SettingsController) {
     let Some(saved) = settings.launcher_position() else {
         center_on_focused_display(window);
         return;
     };
 
-    let rects = monitor_rects(window);
-
-    if rects.is_empty() {
+    if !window.window().has_winit_window() {
         set_outer_position(window, saved);
         return;
     }
+
+    let rects = monitor_rects(window);
 
     if !position_visible_on_any_monitor(saved, &rects) {
         tracing::info!(
@@ -704,11 +708,13 @@ mod tests {
 
     #[test]
     fn position_visible_requires_at_least_one_monitor() {
-        // No monitors in the slice means the pure check can't validate; the
-        // host short-circuits ahead of this call (`apply_saved_or_centered_position`
-        // treats empty rects as "winit window not yet realised, trust the
-        // saved value") so this branch fires only when monitors really are
-        // empty.
+        // Empty rects = winit is alive but `available_monitors()` returned
+        // nothing (e.g. KVM mid-switch, all displays disconnected). The
+        // host falls through to `center_on_focused_display` rather than
+        // trusting the saved value, so the pure check must return false.
+        // The "winit window not yet realised" cold-start case is handled
+        // above `monitor_rects` via `has_winit_window` and never reaches
+        // this branch.
         let pos = WindowPosition { x: 100, y: 100 };
         assert!(!position_visible_on_any_monitor(pos, &[]));
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -277,10 +277,8 @@ pub(crate) fn hide(window: &QueryWindow) {
     quit_if_once();
 }
 
-/// Snapshot the current window position, hand it to the settings
-/// controller (which queues a write on its dedicated writer thread),
-/// then hide. The disk write is decoupled from the dismiss path so the
-/// hide stays observably instant regardless of disk latency.
+/// Persist the current window position, then hide. The position write
+/// is queued onto the settings writer thread so the hide stays snappy.
 pub(crate) fn hide_and_persist_position(window: &QueryWindow, settings: &SettingsController) {
     // Persist-dismiss fires BEFORE the hide so subscribers see the input
     // while it's still live — `clear-input` zeroes the text on hide.
@@ -288,34 +286,20 @@ pub(crate) fn hide_and_persist_position(window: &QueryWindow, settings: &Setting
 
     if let Some(pos) = capture_outer_position(window) {
         settings.set_launcher_position(pos);
-
-        // Single-shot is about to `quit_event_loop` + exit the process,
-        // which would race the writer thread. Force a synchronous flush
-        // so the dragged position actually lands on disk before exit.
-        if ONCE_MODE.load(Ordering::Relaxed) {
-            settings.flush();
-        }
     }
 
     hide(window);
 }
 
-/// Apply the persisted launcher position, falling back to the centered
-/// default when no position is saved or the saved one is no longer on any
-/// connected display. The off-screen check matters when the user unplugs
-/// the monitor the window was last positioned on — without it, the next
-/// show would put the window in the void.
+/// Apply the persisted launcher position, recentering when nothing is
+/// saved or the saved value is no longer on any connected display.
 ///
-/// On cold start the winit window hasn't been realised yet (Slint creates
-/// it in `about_to_wait` on the next event-loop tick), so we can't query
-/// monitors at all. In that case we seed the position into
-/// `WindowAttributes` via `slint::Window::set_position` — winit uses that
-/// as the new window's origin and the off-screen check runs the next time
-/// `show` fires with the winit window live. We distinguish "no winit yet"
-/// from "winit alive but `available_monitors()` is empty" (e.g. KVM
-/// mid-switch, lid closed during wake) so the latter still falls through
-/// to the recenter path and doesn't blindly trust a possibly-off-screen
-/// saved value.
+/// On cold start the winit window doesn't exist yet (Slint creates it on
+/// the next event-loop tick), so we seed `WindowAttributes::position` via
+/// `slint::Window::set_position` and let the off-screen check re-run on
+/// the following show. `has_winit_window()` distinguishes that case from
+/// "winit alive but `available_monitors()` is empty" so the latter still
+/// recenters instead of trusting a possibly-off-screen value.
 fn apply_saved_or_centered_position(window: &QueryWindow, settings: &SettingsController) {
     let Some(saved) = settings.launcher_position() else {
         center_on_focused_display(window);
@@ -354,11 +338,9 @@ fn capture_outer_position(window: &QueryWindow) -> Option<WindowPosition> {
         .flatten()
 }
 
-/// Push the window's outer position. `slint::Window::set_position` resolves
-/// to `winit::Window::set_outer_position` when the winit window is live, and
-/// to `WindowAttributes::position` (consumed at creation) when it isn't —
-/// so this works both for the live re-show path and for the cold-start path
-/// where Slint hasn't realised the winit window yet.
+/// Push the window's outer position. Resolves to
+/// `winit::Window::set_outer_position` when the winit window is live, or
+/// seeds `WindowAttributes::position` for the cold-start path.
 fn set_outer_position(window: &QueryWindow, pos: WindowPosition) {
     window.window().set_position(slint::PhysicalPosition::new(pos.x, pos.y));
 }
@@ -708,13 +690,8 @@ mod tests {
 
     #[test]
     fn position_visible_requires_at_least_one_monitor() {
-        // Empty rects = winit is alive but `available_monitors()` returned
-        // nothing (e.g. KVM mid-switch, all displays disconnected). The
-        // host falls through to `center_on_focused_display` rather than
-        // trusting the saved value, so the pure check must return false.
-        // The "winit window not yet realised" cold-start case is handled
-        // above `monitor_rects` via `has_winit_window` and never reaches
-        // this branch.
+        // Empty rects = winit alive but no monitors connected; the host
+        // falls through to recenter rather than trusting the saved value.
         let pos = WindowPosition { x: 100, y: 100 };
         assert!(!position_visible_on_any_monitor(pos, &[]));
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -6,7 +6,6 @@
 
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::thread;
 use std::time::Instant;
 
 use base64::Engine;
@@ -278,33 +277,23 @@ pub(crate) fn hide(window: &QueryWindow) {
     quit_if_once();
 }
 
-/// Snapshot the current window position, hand it to a background thread
-/// for fire-and-forget persistence, then hide. The disk write must not
-/// block the UI thread — same pattern the frecency picks use — so the
-/// hide is observably instant regardless of disk latency.
+/// Snapshot the current window position, hand it to the settings
+/// controller (which queues a write on its dedicated writer thread),
+/// then hide. The disk write is decoupled from the dismiss path so the
+/// hide stays observably instant regardless of disk latency.
 pub(crate) fn hide_and_persist_position(window: &QueryWindow, settings: &SettingsController) {
     // Persist-dismiss fires BEFORE the hide so subscribers see the input
     // while it's still live — `clear-input` zeroes the text on hide.
     window.invoke_persist_dismiss(window.get_query_text());
 
     if let Some(pos) = capture_outer_position(window) {
-        if ONCE_MODE.load(Ordering::Relaxed) {
-            // In single-shot we're about to `quit_event_loop` and exit
-            // the process — spawning a fire-and-forget thread races the
-            // process death, so do the disk write inline. The user already
-            // committed (Esc/Enter); the extra few ms is invisible.
-            settings.set_launcher_position(pos);
-        } else {
-            let settings = settings.clone();
+        settings.set_launcher_position(pos);
 
-            if let Err(err) = thread::Builder::new()
-                .name("highbeam-settings-position".into())
-                .spawn(move || {
-                    settings.set_launcher_position(pos);
-                })
-            {
-                tracing::warn!(%err, "settings: position-persist thread spawn failed");
-            }
+        // Single-shot is about to `quit_event_loop` + exit the process,
+        // which would race the writer thread. Force a synchronous flush
+        // so the dragged position actually lands on disk before exit.
+        if ONCE_MODE.load(Ordering::Relaxed) {
+            settings.flush();
         }
     }
 

--- a/ui/query.slint
+++ b/ui/query.slint
@@ -171,7 +171,7 @@ export component QueryWindow inherits Window {
     // `select-global` flips the rail selection to the global entry.
     callback capture-hotkey(bool, bool, bool, bool, string) -> bool;
     callback reset-hotkey-to-default();
-    callback cycle-alt-action-modifier();
+    callback set-alt-action-modifier(string);
     callback select-global();
     // Whether the hotkey field is currently listening for a key combo —
     // drives the prompt text + highlighted border in the global pane.
@@ -386,7 +386,7 @@ export component QueryWindow inherits Window {
             cycle-option-enum(plugin, key) => { root.cycle-option-enum(plugin, key); }
             capture-hotkey(meta, ctrl, shift, alt, text) => { return root.capture-hotkey(meta, ctrl, shift, alt, text); }
             reset-hotkey-to-default => { root.reset-hotkey-to-default(); }
-            cycle-alt-action-modifier => { root.cycle-alt-action-modifier(); }
+            set-alt-action-modifier(value) => { root.set-alt-action-modifier(value); }
             select-global => { root.select-global(); }
             recenter-window => { root.recenter-window(); }
             open-config-dir => { root.open-config-dir(); }

--- a/ui/settings_view.slint
+++ b/ui/settings_view.slint
@@ -399,7 +399,20 @@ export component SettingsView {
                                 ComboBox {
                                     width: 160px;
                                     model: ["Alt", "Shift", "Cmd", "Ctrl"];
-                                    current-value: root.alt-action-modifier;
+                                    // `<=>` keeps the binding alive across
+                                    // user picks — a plain `:` binding gets
+                                    // severed the first time ComboBoxBase
+                                    // writes to current-value via select().
+                                    current-value <=> root.alt-action-modifier;
+                                    // current-index is independent of
+                                    // current-value inside ComboBoxBase, so
+                                    // derive it from the saved string or the
+                                    // popup highlight would point at "Alt"
+                                    // regardless of what's actually selected.
+                                    current-index: root.alt-action-modifier == "Shift" ? 1
+                                        : root.alt-action-modifier == "Cmd" ? 2
+                                        : root.alt-action-modifier == "Ctrl" ? 3
+                                        : 0;
                                     selected(value) => {
                                         root.set-alt-action-modifier(value);
                                     }

--- a/ui/settings_view.slint
+++ b/ui/settings_view.slint
@@ -399,16 +399,12 @@ export component SettingsView {
                                 ComboBox {
                                     width: 160px;
                                     model: ["Alt", "Shift", "Cmd", "Ctrl"];
-                                    // `<=>` keeps the binding alive across
-                                    // user picks — a plain `:` binding gets
-                                    // severed the first time ComboBoxBase
-                                    // writes to current-value via select().
+                                    // Two-way: a plain `:` binding gets
+                                    // severed on the first user pick.
                                     current-value <=> root.alt-action-modifier;
-                                    // current-index is independent of
-                                    // current-value inside ComboBoxBase, so
-                                    // derive it from the saved string or the
-                                    // popup highlight would point at "Alt"
-                                    // regardless of what's actually selected.
+                                    // ComboBoxBase keeps current-index
+                                    // independent of current-value, so
+                                    // derive it from the saved string.
                                     current-index: root.alt-action-modifier == "Shift" ? 1
                                         : root.alt-action-modifier == "Cmd" ? 2
                                         : root.alt-action-modifier == "Ctrl" ? 3

--- a/ui/settings_view.slint
+++ b/ui/settings_view.slint
@@ -9,7 +9,7 @@
 // functions, which are forwarded through the `focus-rail` and
 // `sync-rail` public functions below.
 
-import { ScrollView } from "std-widgets.slint";
+import { ScrollView, ComboBox } from "std-widgets.slint";
 import { PluginSlot, PluginOption } from "types.slint";
 
 export component SettingsView {
@@ -51,7 +51,7 @@ export component SettingsView {
     callback recenter-window();
     callback open-config-dir();
     callback sync-rail-selection();
-    callback cycle-alt-action-modifier();
+    callback set-alt-action-modifier(string);
 
     // Called by QueryWindow.show-settings() to give the rail immediate focus.
     public function focus-rail() {
@@ -394,23 +394,14 @@ export component SettingsView {
                                 color: root.foreground-color;
                                 font-size: root.font-size-title;
                             }
-                            TouchArea {
-                                width: 220px;
-                                height: 28px;
-                                clicked => {
-                                    root.cycle-alt-action-modifier();
-                                }
-                                Rectangle {
-                                    background: root.muted-color.with-alpha(0.08);
-                                    border-radius: 4px;
-                                    border-width: 1px;
-                                    border-color: root.border-color;
-                                    Text {
-                                        x: 8px;
-                                        text: root.alt-action-modifier + "  (click to cycle: Alt / Shift / Cmd / Ctrl)";
-                                        color: root.foreground-color;
-                                        font-size: root.font-size-subtitle;
-                                        vertical-alignment: center;
+                            HorizontalLayout {
+                                alignment: start;
+                                ComboBox {
+                                    width: 160px;
+                                    model: ["Alt", "Shift", "Cmd", "Ctrl"];
+                                    current-value: root.alt-action-modifier;
+                                    selected(value) => {
+                                        root.set-alt-action-modifier(value);
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary

- **Position bug**: `slint::Window::show()` defers winit-window creation to `about_to_wait`, so the post-show `apply_saved_or_centered_position` ran while `with_winit_window` still returned `None`. `monitor_rects` was empty, the off-screen check tripped, and the centered fallback also no-op'd — so on cold start the window opened at the OS default. Subsequent re-shows worked because winit had created the window by then.
- Switched `set_outer_position` to `slint::Window::set_position`, which seeds `WindowAttributes::position` when the winit window isn't realised yet and calls `winit::set_outer_position` when it is. Trust the saved position when monitors aren't enumerable yet; validation re-runs the next show.
- Also swapped the alt-action click-to-cycle `TouchArea` for a `ComboBox`.

## Known limitation

The new `ComboBox` is the stock std-widgets one, so it does not match the custom Rectangle/Text styling the rest of the settings panel uses. Acceptable for now; replace with a themed popup later.