### PR TITLE
chore: codebase style sweep + CI cost trim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,7 @@
-# Two parallel jobs (not a matrix): macOS is the primary target with
-# the full lint/test/release-build gate, Linux is the secondary path
-# covering the same checks on `ubuntu-latest`. Kept as separate jobs
-# instead of a matrix because the macOS step would otherwise need
-# guards around platform-specific tooling (qlmanage for `just icon`,
-# the macOS keychain for signing) and the Linux job conversely needs
-# system-package install steps that don't apply to macOS.
+# Linux is the full gate (fmt → lint → pedantic clippy → test). macOS runs
+# only clippy + test to cover the `cfg(target_os = "macos")` code Linux
+# can't compile — macOS runner minutes bill at ~10x, so it's kept minimal.
+# The release profile is verified at tag time by release.yml, not here.
 name: CI
 
 on:
@@ -13,63 +10,12 @@ on:
   pull_request:
     branches: [master]
 
-# Cancel superseded runs on the same ref. Saves runner-minutes when a PR
-# is force-pushed during review.
+# Cancel superseded runs on the same ref (e.g. a force-push during review).
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  cargo:
-    name: cargo (macos)
-    runs-on: macos-latest
-    timeout-minutes: 30
-
-    steps:
-      - uses: actions/checkout@v4
-
-      # rust-toolchain.toml pins channel=stable + clippy + rustfmt, so
-      # dtolnay/rust-toolchain@stable resolves to the same toolchain that
-      # local devs run. No `with: toolchain:` override on purpose.
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-
-      # Keys cache by Cargo.lock + rustc version; hits on most PRs.
-      - name: Cache cargo registry + target
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install just
-        uses: taiki-e/install-action@just
-
-      # Step order mirrors `just check` (fmt → lint → test) plus the extras
-      # the local dev policy asks for (pedantic clippy + release build).
-
-      - name: cargo fmt --check
-        run: cargo fmt -- --check
-
-      # `just lint` is strict clippy with -D warnings -A clippy::pedantic.
-      - name: just lint
-        run: just lint
-
-      # Local policy is "zero pedantic findings or addressed inline". CI
-      # enforces strict (fail on pedantic) so the bar can't drift on PRs.
-      # We override `just lint-pedantic` here to add -D warnings — the
-      # Justfile recipe runs advisory-only for local iteration.
-      - name: clippy pedantic (strict)
-        run: cargo clippy --all-targets --all-features -- -D warnings
-
-      # `cargo test` over `cargo nextest run` on purpose — matches what
-      # local devs run, consistency over a marginal speed win.
-      - name: cargo test --all
-        run: cargo test --all
-
-      # Sanity check that the production profile compiles too. Caught
-      # locally by `just run --release` but devs rarely do that.
-      - name: cargo build --release
-        run: cargo build --release
-
   cargo-linux:
     name: cargo (linux)
     runs-on: ubuntu-latest
@@ -89,13 +35,8 @@ jobs:
       - name: Install just
         uses: taiki-e/install-action@just
 
-      # Linux build needs system libs that don't ship in the Ubuntu
-      # runner image by default. libxkbcommon is winit's keymap
-      # backend; libssl-dev backs reqwest's rustls system-roots
-      # loader (rustls itself is vendored; the -dev package is for
-      # the system cert store linkage); libfontconfig1-dev backs
-      # freedesktop-icons' fontconfig probe used by the Linux icon
-      # fetcher. pkg-config keeps these discoverable.
+      # libxkbcommon: winit keymap backend. libssl-dev: system cert-store
+      # linkage for reqwest. libfontconfig1-dev: freedesktop-icons probe.
       - name: Install Linux build deps
         run: |
           sudo apt-get update
@@ -108,17 +49,33 @@ jobs:
       - name: just lint
         run: just lint
 
+      # Strict: pedantic warnings (enabled in Cargo.toml) fail CI.
       - name: clippy pedantic (strict)
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: cargo test --all
         run: cargo test --all
 
-      - name: cargo build --release
-        run: cargo build --release
+  cargo-macos:
+    name: cargo (macos)
+    runs-on: macos-latest
+    timeout-minutes: 30
 
-      # Linux package builds (just bundle-linux: deb / pacman / rpm /
-      # tarball) are NOT in CI v1 — they need dpkg-deb, makepkg
-      # (Arch-only), and cargo-generate-rpm. Verifying their config
-      # parses is enough for now; the maintainer runs them locally
-      # before tagging releases. Track in the Roadmap.
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@v2
+
+      # clippy + test only — the value here is compiling/linting/running the
+      # macOS-specific code paths; fmt and the lint baseline are Linux's job.
+      - name: clippy pedantic (strict)
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: cargo test --all
+        run: cargo test --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -62,7 +62,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -45,7 +45,7 @@ jobs:
           - xkcd
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -24,7 +24,6 @@ concurrency:
 jobs:
   vitest:
     name: vitest (${{ matrix.plugin }})
-    # Node/vitest is platform-agnostic — no need for 10x-billed macOS.
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1,17 +1,8 @@
-# vitest for every default plugin that ships a package.json + test script.
-# Matrix-per-plugin so a single failing plugin doesn't mask others, and
-# runs go parallel.
-#
-# Plugin list is hardcoded — if a new plugin lands under `plugins/` with
-# its own package.json, append it to the matrix below. `frecency-demo`
-# and `slow-echo` are intentionally absent: they have no package.json
-# (pure JS demos, no JS-side tests).
+# Per-plugin vitest matrix (one failure doesn't mask the rest). Add a plugin
+# to the matrix below when it gains a package.json with tests.
 name: Plugins
 
-# Path-filtered: plugin tests only run when something they actually
-# exercise has changed. `sdk/**` covers the highbeam SDK that every
-# plugin imports from, and the workflow file itself is included so
-# CI changes still trigger a self-test.
+# Path-filtered: sdk/** is included because every plugin imports it.
 on:
   push:
     branches: [master]
@@ -33,7 +24,8 @@ concurrency:
 jobs:
   vitest:
     name: vitest (${{ matrix.plugin }})
-    runs-on: macos-latest
+    # Node/vitest is platform-agnostic — no need for 10x-billed macOS.
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # fetch-depth: 0 so the release job can `git describe` across the
       # full history when computing the previous-tag range.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -111,7 +111,7 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -190,7 +190,7 @@ jobs:
 
     steps:
       # fetch-depth: 0 for the `git describe` / `git log` range below.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,6 @@
-# Release pipeline for high-beam. Triggers strictly on `v*` tags, never on
-# branch push / PR — tagging is the explicit "publish a release" intent.
-#
-# Pipeline shape:
-#   build-macos (macos-latest)  → .app + .dmg (signed when secrets present)
-#   build-linux (ubuntu-latest) → tarball + .deb + .rpm + .pkg.tar.zst
-#   release     (ubuntu-latest) → AI-summarised notes + GitHub release
-#
-# The release job tolerates a flaky GitHub Models API by falling back to
-# the raw commit log — the inference endpoint going down should never
-# block a tag from publishing.
+# Tag-driven (`v*`) release: build macOS + Linux bundles, then publish a
+# GitHub release with AI-summarised notes (falls back to the raw commit log
+# if the Models endpoint is down, so a tag always publishes).
 name: Release
 
 on:
@@ -163,10 +155,6 @@ jobs:
         with:
           tool: cargo-generate-rpm
 
-      # These four recipes are added by the sibling agent wiring Linux
-      # packaging. They wrap `cargo packager --release --formats <fmt>` so
-      # the workflow stays format-agnostic. If a recipe is renamed, update
-      # the matching `just` call below.
       - name: Build tarball
         run: just bundle-tarball
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,27 +8,15 @@ description = "Native Rust keyboard launcher (Spotlight / Alfred / Raycast / Ula
 authors = ["Bas Bieling"]
 homepage = "https://github.com/Mechazawa/high-beam"
 
-# `cargo packager` (the Tauri team's bundler) reads this table to produce
-# `target/release/HighBeam.app` + `target/release/HighBeam_<ver>_*.dmg`.
-# Install once with `cargo install cargo-packager --locked`, then
-# `just bundle` produces both artifacts.
+# Read by `cargo packager` (via `just bundle`) to produce the .app/.dmg.
 [package.metadata.packager]
 product-name = "HighBeam"
 identifier = "at.ioexception.highbeam"
-# `binaries` tells the packager which build outputs to bundle; the path is
-# relative to `out-dir` and resolved against the cargo target dir at runtime.
 binaries = [{ path = "high-beam", main = true }]
 icons = ["bundle/icon.icns", "bundle/icon.png"]
-# The plugins land in `Contents/Resources/plugins/<name>/...` at bundle
-# time; `src/daemon.rs::install_default_plugins_if_needed` copies them to
-# the user's plugin dir on first launch. Dev-only fixtures
-# (`echo`, `echo-ts`, `slow-echo`, `frecency-demo`) deliberately stay out
-# of the shipped bundle.
-# When `src` resolves to a single file, cargo-packager uses `target`
-# verbatim as the destination filename inside Contents/Resources — so each
-# entry spells out its full target path. Dev-only files (package.json,
-# vitest configs, node_modules, *.test.*, lockfiles) stay out of the
-# bundle by simply not being listed.
+# Each entry spells out its full target path; dev-only plugins/fixtures are
+# excluded by omission. The daemon seeds these into the user plugin dir on
+# first launch (src/daemon.rs).
 resources = [
     { src = "plugins/app-launcher/manifest.json",      target = "plugins/app-launcher/manifest.json" },
     { src = "plugins/app-launcher/plugin.js",          target = "plugins/app-launcher/plugin.js" },
@@ -82,17 +70,8 @@ resources = [
     { src = "themes/solarized.toml",                            target = "themes/solarized.toml" },
     { src = "themes/tokyo-night.toml",                          target = "themes/tokyo-night.toml" },
 ]
-# `app`+`dmg` are macOS; `deb`/`pacman` are Linux. cargo-packager only
-# emits the format(s) valid for the current host OS — running on macOS
-# produces .app + .dmg, running on Linux produces .deb + the pacman
-# (.tar.gz + PKGBUILD) pair. The Justfile recipes drive per-format
-# builds explicitly via `--formats <name>` so a missing tool on the
-# host (dpkg-deb, makepkg, etc.) only fails that one recipe.
-#
-# .rpm is NOT in this list: cargo-packager 0.11.x doesn't ship an rpm
-# backend. We document the rpm path via `cargo-generate-rpm` in
-# docs/distribution.md; the `bundle-rpm` Justfile recipe defers to
-# that.
+# cargo-packager emits only the formats valid for the host OS. .rpm is
+# absent (no backend in 0.11.x) — handled separately via cargo-generate-rpm.
 formats = ["app", "dmg", "deb", "pacman"]
 
 [package.metadata.packager.linux]
@@ -143,17 +122,9 @@ window-size = { width = 660, height = 400 }
 app-position = { x = 180, y = 170 }
 application-folder-position = { x = 480, y = 170 }
 
-# .rpm packaging via cargo-generate-rpm. cargo-packager 0.11 has no rpm
-# backend, so we drive it separately. The `bundle-rpm` Justfile recipe
-# stages files into `target/rpm-stage/` mirroring the on-disk install
-# layout used by the .deb / tarball, then `cargo generate-rpm` reads this
-# table to produce the package. Fields not listed here (Name, Version,
-# Summary, License, URL) are inherited from [package].
-#
-# `auto-req = "no"` because we list the runtime deps explicitly under
-# `[…requires]` below — the auto-discoverer over-collects every libc and
-# linker SONAME ELF reference, and Fedora/openSUSE name those differently
-# enough that the auto list often won't resolve cleanly.
+# `just bundle-rpm` stages files then runs `cargo generate-rpm` off this
+# table. `auto-req = "no"`: the auto-discoverer over-collects SONAMEs that
+# Fedora/openSUSE name differently, so we list runtime deps explicitly below.
 [package.metadata.generate-rpm]
 auto-req = "no"
 assets = [
@@ -171,20 +142,9 @@ openssl-libs = "*"
 fontconfig = "*"
 libxkbcommon = "*"
 
-# Release-profile knobs for the bundled binary. The launcher is mostly idle
-# between keystrokes, so single-digit-ms wins from cross-crate optimisation
-# add up over a session of hundreds of queries.
-#
-# * `lto = "fat"` + `codegen-units = 1` — give LLVM the whole program for
-#   inlining; pays ~3–5 min compile time per release for ~10–15% smaller
-#   binary + measurable hot-path speedup.
-# * `strip = true` — strip debug symbols from the shipped binary. Halves
-#   the .app payload; symbols stay in `target/release/deps/*.dSYM` so
-#   stack traces from a crash report can still be resolved locally.
-# * `panic` is deliberately left at the default `unwind` — a panicking
-#   plugin task (icon extractor, archive extractor, etc.) must surface as
-#   a `JoinError` the dispatcher can recover from, not take the daemon
-#   down. `panic = "abort"` would silently regress that.
+# lto/codegen-units: smaller + faster binary at the cost of release compile
+# time. `panic` is deliberately left at `unwind` — a panicking plugin task
+# must surface as a recoverable JoinError, not abort the daemon.
 [profile.release]
 lto = "fat"
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,8 +143,10 @@ fontconfig = "*"
 libxkbcommon = "*"
 
 # lto/codegen-units: smaller + faster binary at the cost of release compile
-# time. `panic` is deliberately left at `unwind` — a panicking plugin task
-# must surface as a recoverable JoinError, not abort the daemon.
+# time. strip: the shipped binary is stripped, but symbols stay in
+# target/release/deps/*.dSYM so crash reports still resolve locally. panic is
+# deliberately left at `unwind` — a panicking plugin task must surface as a
+# recoverable JoinError, not abort the daemon.
 [profile.release]
 lto = "fat"
 codegen-units = 1

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -125,9 +125,9 @@ the same payload:
 ```
 
 The bundled plugin set matches the macOS `.app`'s
-`[package.metadata.packager].resources` list — the 16 "real" plugins,
-with the dev fixtures (`echo`, `echo-ts`, `slow-echo`, `frecency-demo`)
-excluded by name in the tarball recipe.
+`[package.metadata.packager].resources` list — the real plugins, with the
+dev fixtures (`echo`, `echo-ts`, `slow-echo`, `frecency-demo`) excluded by
+name in the tarball recipe.
 
 ### First-launch install on Linux
 

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -10,8 +10,8 @@
 
 ### macOS
 
-`global-hotkey` registers `Shift+Space` at startup. The hotkey is currently
-hardcoded; user configurability is post-v1.
+`global-hotkey` registers `Shift+Space` at startup. The combo is
+configurable in Settings → Global and re-registered live.
 
 If macOS prompts for input-monitoring or accessibility permission, grant it
 once — High Beam itself doesn't need it (the `global-hotkey` crate operates

--- a/docs/sdk-reference.md
+++ b/docs/sdk-reference.md
@@ -97,9 +97,9 @@ Notes:
   `data:image/<type>;base64,...` URI) but is not in the `Result` interface
   exported from `types.d.ts`. Set it as a property anyway — the host reads
   it. `plugins/app-launcher` does this.
-- `Action` has two host-only variants (`{ kind: 'quit' }` and
-  `{ kind: 'noop' }`) emitted by the Core built-in. Plugins don't construct
-  them.
+- `Action` has host-only variants (`quit`, `openSettings`, `reloadPlugin`,
+  `installPlugin`, `updatePlugins`, `noop`) emitted by the Core built-in.
+  Plugins don't construct them.
 
 ## `highbeam:actions`
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -64,14 +64,22 @@ height grows with result count up to a hardcoded cap (~9 rows).
 
 `border_radius` is in pixels.
 
-## Example: dark mode
+## Dark / light mode
+
+Each `[colors]`, `[font]`, and `[window]` table may carry `.dark` / `.light`
+sub-tables that override the base for the matching appearance; anything a
+sub-table omits inherits from the base above it. The `theme_mode` setting in
+`settings.toml` chooses which to paint — `"auto"` (default: follows the OS
+and repaints live when it flips), `"dark"`, or `"light"`.
+
+TOML requires the base fields before any sub-table:
 
 ```toml
 [colors]
+background = "#ffffffea"   # light base
+foreground = "#1d1d1f"
+
+[colors.dark]              # applied in dark mode
 background = "#1c1c1eee"
 foreground = "#f5f5f7"
-muted      = "#8e8e93"
-highlight  = "#0a84ff"
-selection  = "#0a84ff44"
-border     = "#ffffff10"
 ```

--- a/plugins/currency-converter/plugin.js
+++ b/plugins/currency-converter/plugin.js
@@ -203,9 +203,8 @@ function formatAmount(value, precision) {
     if (!Number.isFinite(value)) return null;
     const fixed = value.toFixed(precision);
     if (precision === 0) return fixed;
-    // Trim *only* trailing zeros that don't reduce precision below the cap.
-    // We deliberately keep all `precision` digits — users asked for 2 dp,
-    // they get 2 dp even if the result is round.
+    // Keep all `precision` digits even when the result is round — users who
+    // asked for 2 dp get 2 dp.
     return fixed;
 }
 

--- a/plugins/dictionary-linux/plugin.js
+++ b/plugins/dictionary-linux/plugin.js
@@ -12,13 +12,10 @@ import { isLinux } from "highbeam:platform";
 const TRIGGERS = ["define ", "dict "];
 const SUBTITLE_MAX = 80;
 const MAX_RESULTS = 3;
-// Defs come back small from `wn`/`dict`; cap stdout collection at 1 MiB so a
-// pathological output can't drown the runtime.
 const EXEC_TIMEOUT_MS = 1200;
 
-// Tool detection cache — `which` is cheap but not free, and the host
-// re-imports the module rarely so this survives across queries.
-// `null` = not yet probed; `false` = probed and missing; `true` = available.
+// Tool-probe cache, surviving across queries. `null` = not yet probed,
+// `false` = probed and missing, `true` = available.
 const toolCache = {
     wn: null,
     dict: null,
@@ -40,28 +37,13 @@ async function which(tool, signal) {
     return toolCache[tool];
 }
 
-// `wn <word> -over` (the "overview" report) groups senses by part-of-speech
-// using stanzas that look like:
-//
-//   Overview of noun rust
-//
-//   The noun rust has 4 senses (first 1 from tagged texts)
-//
+// `wn <word> -over` sense lines look like:
 //   1. (5) rust, rusting -- (a red or brown oxide coating on iron...)
-//   2. corrosion, rusting -- (a destructive process...)
-//
-//   Overview of verb rust
-//   ...
-//
-// Each sense line starts with `<n>.` optionally followed by `(freq)`,
-// then a comma-separated synonym list, then ` -- ` and `(definition)`
-// (the definition may include `; "example"` suffixes inside the parens).
-// We strip the outer parens and keep everything inside as the definition.
+// i.e. `<n>.` + optional `(freq)` + synonyms + ` -- ` + `(definition)`. We
+// keep the inside of the outer parens as the definition.
 function parseWordNetOverview(stdout) {
     const senses = [];
-    // Match across the whole text in case lines are wrapped — wn does wrap
-    // long synonym lists. The non-greedy `[\s\S]*?` plus a lookahead handles
-    // both end-of-line and the next sense / next overview header.
+    // Whole-text match (`[\s\S]*?`) since wn wraps long synonym lists.
     const re = /^\s*\d+\.\s*(?:\(\d+\)\s*)?([\s\S]*?)\s--\s\(([\s\S]*?)\)\s*$/gm;
     let m;
     while ((m = re.exec(stdout)) !== null) {
@@ -75,25 +57,9 @@ function parseWordNetOverview(stdout) {
     return senses;
 }
 
-// `dict <word>` output looks like:
-//
-//   3 definitions found
-//
-//   From The Collaborative International Dictionary of English v.0.48 [gcide]:
-//
-//     Rust \Rust\, n. ...
-//        1. (Chem.) The reddish yellow coating ...
-//        2. A minute fungus ...
-//
-//   From WordNet (r) 3.0 (2006) [wn]:
-//
-//     rust
-//         n 1: a red or brown oxide coating ...
-//
-// Multi-database: we collect each `From ... [<short>]:` block's body and
-// flatten the leading whitespace; the first non-empty block is the headline
-// definition. We surface only the first block — the second is usually a
-// near-duplicate (e.g. WordNet repeated under the dict umbrella).
+// `dict <word>` emits one `From <source> [<short>]:` block per database. We
+// take the first block's body as the headline (later blocks are usually
+// near-duplicates) and flatten its leading indent.
 function parseDictOutput(stdout) {
     const lines = stdout.split("\n");
     const blocks = [];

--- a/plugins/unit-conversions/plugin.js
+++ b/plugins/unit-conversions/plugin.js
@@ -1,21 +1,9 @@
 import { copy } from "highbeam:actions";
 
-// Hand-rolled units table. Each unit declares the category it belongs to plus
-// a linear conversion to that category's base unit: `base = value * scale + offset`.
-// Only temperature uses a non-zero offset; everything else is a pure ratio.
-//
-// Base units per category:
-//   length      -> meter
-//   mass        -> gram
-//   temperature -> kelvin
-//   volume      -> liter
-//   time        -> second
-//   data        -> byte
-//   area        -> square meter
-//
-// Lookup keys are case-sensitive on purpose so we can distinguish `K` (kelvin)
-// from `k`-prefixes and `KB` (1000) from `kB`. Aliases below add common
-// case-insensitive forms where ambiguity is impossible.
+// Units table: each entry is a linear conversion to its category's base
+// unit, `base = value * scale + offset` (only temperature has an offset).
+// Keys are case-sensitive on purpose — to keep `K` (kelvin) distinct from
+// `k`-prefixes and `KB` (1000) from `kB`.
 
 const UNITS = {
     // length (base: meter)

--- a/plugins/xkcd/plugin.js
+++ b/plugins/xkcd/plugin.js
@@ -1,13 +1,7 @@
-// xkcd comic lookup. Triggered by `xkcd <arg>`:
-//   - `xkcd latest`     → newest comic
-//   - `xkcd random`     → uniformly random comic from 1..latest
-//   - `xkcd <number>`   → that comic by number (404 → no results)
-//   - `xkcd <text>`     → fuzzy title search against a cached index
-//
-// The title index is cached to `fs.cache` as `xkcd-index.json`. The
-// `onEnable` hook rebuilds the full archive on install / update; in the
-// meantime the first text search bootstraps the latest 500 comics (~10s)
-// and subsequent loads refresh incrementally.
+// xkcd lookup via `xkcd <arg>`: `latest`, `random`, a number, or text
+// (fuzzy title search against a cached index). The index lives in fs.cache;
+// `onEnable` rebuilds the full archive, otherwise the first text search
+// bootstraps the latest 500 and later loads refresh incrementally.
 
 import { openUrl } from "highbeam:actions";
 import { get } from "highbeam:http";

--- a/sdk/highbeam/fs.d.ts
+++ b/sdk/highbeam/fs.d.ts
@@ -27,9 +27,9 @@ export interface ReadFileOptions {
 }
 
 /**
- * Walk a directory. Yields one [`DirEntry`] per entry; with
- * `{ recursive: true }`, descends into subdirectories before yielding their
- * children's sibling directories.
+ * Walk a directory, yielding one [`DirEntry`] per entry. With
+ * `{ recursive: true }` it also yields entries in nested subdirectories
+ * (depth-first; order within a directory is OS-dependent / unspecified).
  *
  * Cap: `fs.read`.
  */

--- a/src/window.rs
+++ b/src/window.rs
@@ -209,18 +209,10 @@ pub(crate) fn apply_theme(window: &QueryWindow, theme: &ThemeVariant) {
 }
 
 /// Show the window, position it (saved or centered), and focus the input.
-/// Idempotent — calling while already visible re-applies position and
-/// re-focuses ("focuses it if already open").
-///
-/// Focus-grab is platform-specific:
-/// * macOS uses `NSApp.activate(ignoringOtherApps:)` +
-///   `makeKeyAndOrderFront`; no token plumbing.
-/// * Wayland uses `xdg_activation_v1.activate(token, surface)` — the
-///   `activation_token` is forwarded from the invoking process (terminal
-///   keybind, IPC `--open`, etc.). Without it the compositor will not
-///   raise our surface above whatever is currently focused, and on
-///   GNOME-Mutter the launcher silently opens behind the active window.
-/// * X11 / other paths ignore the token; winit handles focus there.
+/// Idempotent. Focus-grab is platform-specific; on Wayland it needs
+/// `activation_token` (forwarded from the invoking process) or the
+/// compositor won't raise the surface — GNOME-Mutter opens it behind the
+/// active window. macOS uses `NSApp.activate`; X11 lets winit handle it.
 pub(crate) fn show(window: &QueryWindow, settings: &SettingsController, activation_token: Option<&str>) {
     // On Linux the previous dismiss may have left us in the `is-hidden`
     // collapsed-1×1 state instead of going through Slint's hide (which is
@@ -251,20 +243,15 @@ pub(crate) fn show(window: &QueryWindow, settings: &SettingsController, activati
     window.invoke_focus_input();
 }
 
-/// Hide the window. Clears the input text so the next open starts fresh —
-/// every close path (Esc, blur, programmatic) funnels through here.
-/// Does *not* persist position; use [`hide_and_persist_position`] for the
-/// user-driven close paths.
+/// Hide the window and clear the input so the next open starts fresh. Does
+/// *not* persist position — use [`hide_and_persist_position`] for that.
 ///
-/// On Linux this DELIBERATELY does NOT call `Window::hide()`. Slint 1.16's
-/// Wayland hide path destroys the underlying winit window via `suspend()`,
-/// and when the destroy fails (because Slint's renderer holds extra
-/// `Arc<winit::Window>` refs we can't drop from app code) the state still
-/// flips to "None" — so the *next* `show()` won't re-attach the surface
-/// and the launcher silently never opens again. Instead we set an
-/// `is-hidden` flag in the .slint file that collapses the visible content
-/// to 1×1 transparent, keeping Slint's `shown` state intact so subsequent
-/// activations work.
+/// On Linux this DELIBERATELY avoids `Window::hide()`: Slint 1.16's Wayland
+/// hide destroys the winit window and, when the destroy fails (renderer
+/// holds extra `Arc<winit::Window>` refs), leaves state in "None" so the
+/// next `show()` never re-attaches — the launcher silently dies. Instead we
+/// flip an `is-hidden` flag that collapses content to 1×1, keeping Slint's
+/// `shown` state intact.
 pub(crate) fn hide(window: &QueryWindow) {
     window.invoke_clear_input();
     #[cfg(target_os = "linux")]

--- a/ui/query.slint
+++ b/ui/query.slint
@@ -106,8 +106,6 @@ export component QueryWindow inherits Window {
     in-out property <color> background-color: #ffffffea;
     in-out property <color> foreground-color: #1d1d1f;
     in-out property <color> muted-color: #86868b;
-    // `highlight` is part of the documented token surface but not yet bound in
-    // markup — kept so user themes can set it without parse errors.
     in-out property <color> highlight-color: #0a84ff;
     in-out property <color> selection-color: #0a84ff33;
     in-out property <color> border-color: #00000010;


### PR DESCRIPTION
- Drop the release build from PR CI, trim the macOS job to clippy+test, move plugin vitest to ubuntu.
- Trim verbose/stale comments in the CI and Cargo config.
- Fix stale or contradictory comments and docs surfaced by a full-codebase audit.
- No behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)