### PR TITLE
feat(theme): theme folder + styled selector with live reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ reference: [docs/sdk-reference.md](docs/sdk-reference.md).
 
 ## Theming
 
-`theme.toml` in the config dir overrides the bundled
-yosemite-spotlight default. Token reference:
-[docs/theming.md](docs/theming.md).
+Drop a `<name>.toml` in the `themes/` folder in the config dir and pick
+it in Settings → Global → Theme; `default` is the bundled
+yosemite-spotlight. Token reference: [docs/theming.md](docs/theming.md).
 
 ## Internals
 

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -85,7 +85,8 @@ detects it (connect fails) and replaces it.
 
 | Purpose             | macOS                                                   | Linux                                              |
 |---------------------|---------------------------------------------------------|----------------------------------------------------|
-| Config (`theme.toml`) | `~/Library/Application Support/high-beam/`            | `$XDG_CONFIG_HOME/high-beam/`                      |
+| Config (`settings.toml`) | `~/Library/Application Support/high-beam/`         | `$XDG_CONFIG_HOME/high-beam/`                      |
+| Themes              | `~/Library/Application Support/high-beam/themes/`       | `$XDG_CONFIG_HOME/high-beam/themes/`               |
 | Plugins             | `~/Library/Application Support/high-beam/plugins/`      | `$XDG_DATA_HOME/high-beam/plugins/`                |
 | Plugin cache        | `~/Library/Caches/high-beam/plugins/<name>/`            | `$XDG_CACHE_HOME/high-beam/plugins/<name>/`        |
 | Frecency DB         | `~/Library/Application Support/high-beam/frecency.sqlite` | `$XDG_DATA_HOME/high-beam/frecency.sqlite`       |

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,18 +1,28 @@
 # Theming
 
-High Beam reads a single `theme.toml` from the platform config dir at
-startup. Edit it and restart the daemon to apply changes.
+High Beam reads themes from a `themes/` folder in the platform config
+dir. Each `<name>.toml` in that folder is a selectable theme.
 
-- macOS: `~/Library/Application Support/high-beam/theme.toml`
-- Linux: `$XDG_CONFIG_HOME/high-beam/theme.toml` (default
-  `~/.config/high-beam/theme.toml`)
+- macOS: `~/Library/Application Support/high-beam/themes/`
+- Linux: `$XDG_CONFIG_HOME/high-beam/themes/` (default
+  `~/.config/high-beam/themes/`)
 
-A missing file silently falls back to the bundled default. A malformed
-file logs a warning and still falls back, so a typo can't prevent the
-daemon from starting.
+On first launch from a packaged build, the shipped themes are seeded
+into this folder (new shipped themes from later updates are added too,
+but a file you've edited is never overwritten).
 
-The bundled default lives at `themes/yosemite-spotlight.toml`; copy it
-as a starting point.
+Pick the active theme in Settings → Global → Theme. The dropdown lists
+`default` (the builtin yosemite-spotlight, used when no file is selected)
+plus every `<name>.toml` in the folder. After editing a theme file, hit
+**Reload theme** next to the dropdown to re-read and apply it without a
+restart. The list itself refreshes whenever you open Settings, so a file
+you just dropped in (or removed) shows up on the next open.
+
+A missing or malformed file silently falls back to the builtin, so a
+typo or a stale selection can't prevent the daemon from starting.
+
+To author a new theme, copy any seeded file (e.g.
+`themes/yosemite-spotlight.toml`) and edit it.
 
 ## Token reference
 
@@ -52,8 +62,8 @@ warning and the default value is used for that field.
 ### Fonts
 
 `family` accepts a CSS-style fallback list. An empty string lets Slint's
-backend pick the OS default — that's how a missing `theme.toml` matches the
-pre-theming build visually.
+backend pick the OS default — that's how the builtin `default` theme matches
+the pre-theming build visually.
 
 The `size_*` fields are pixels.
 

--- a/src/bundle_install.rs
+++ b/src/bundle_install.rs
@@ -1,13 +1,15 @@
-//! First-launch install of default plugins shipped inside the macOS .app bundle.
+//! First-launch install of default plugins and themes shipped inside the
+//! packaged app.
 //!
 //! When the daemon starts from a packaged `HighBeam.app`, the bundled
-//! defaults live in `Contents/Resources/plugins/` — a read-only location the
-//! user shouldn't edit. The user-editable copy lives in the platform plugin
-//! directory ([`crate::plugins::loader`]'s default search target). The very
-//! first time we boot we copy the bundled defaults into the user dir;
-//! thereafter the user's copy wins and `cargo packager` updates never stomp
-//! on it. Running unbundled (`cargo run`) hits the "no bundled dir" branch
-//! and quietly does nothing.
+//! defaults live in `Contents/Resources/<plugins|themes>/` — a read-only
+//! location the user shouldn't edit. The user-editable copies live in the
+//! platform plugin / themes directories. Plugins seed once (only into an
+//! empty/absent dir, so the user's copy always wins thereafter); themes seed
+//! per-file (any shipped theme not already present is copied, but an existing
+//! file — possibly user-edited — is never overwritten). Running unbundled
+//! (`cargo run`, `cargo install`) hits the "no bundled dir" branch and quietly
+//! does nothing.
 
 use std::fs;
 use std::io;
@@ -75,24 +77,69 @@ pub fn install_default_plugins_if_needed() {
     }
 }
 
+/// Seed the shipped default themes into the user's themes dir, copying any
+/// `.toml` not already present. Unlike plugins this runs per-file every
+/// launch (add-missing-only): new builtin themes from an app update appear
+/// without clearing the folder, but an existing file — which the user may
+/// have edited — is never overwritten. Errors are logged and swallowed.
+pub fn install_default_themes_if_needed() {
+    let Some(user_dir) = crate::paths::themes_dir() else {
+        tracing::debug!("bundle-install: no platform themes dir; skipping");
+
+        return;
+    };
+
+    let Some(bundled) = bundled_resource_dir("themes") else {
+        tracing::debug!("bundle-install: no bundled themes; running unbundled");
+
+        return;
+    };
+
+    if let Err(err) = fs::create_dir_all(&user_dir) {
+        tracing::warn!(themes_dir = %user_dir.display(), %err, "bundle-install: failed to create user themes dir");
+
+        return;
+    }
+
+    match copy_missing_files(&bundled, &user_dir, "toml") {
+        Ok(0) => tracing::debug!(themes_dir = %user_dir.display(), "bundle-install: no new themes to seed"),
+        Ok(copied) => tracing::info!(
+            themes_dir = %user_dir.display(),
+            source = %bundled.display(),
+            copied,
+            "bundle-install: seeded default themes",
+        ),
+        Err(err) => tracing::warn!(
+            source = %bundled.display(),
+            target = %user_dir.display(),
+            %err,
+            "bundle-install: theme seed failed",
+        ),
+    }
+}
+
 /// Resolve the bundled plugin dir relative to the running executable.
+/// Thin wrapper over [`bundled_resource_dir`] — see its docs for the layout.
+fn bundled_plugins_dir() -> Option<PathBuf> {
+    bundled_resource_dir("plugins")
+}
+
+/// Resolve a bundled resource subdirectory (`plugins`, `themes`, …) relative
+/// to the running executable.
 ///
 /// In a `.app` bundle the binary sits at `HighBeam.app/Contents/MacOS/high-beam`,
-/// so the resources directory is two parents up + `Resources/plugins`. When
-/// the binary lives anywhere else (`target/release/high-beam`, `cargo run`,
-/// `cargo install`'d into `~/.cargo/bin`), the computed path won't exist and
-/// we return `None`.
-fn bundled_plugins_dir() -> Option<PathBuf> {
+/// so the resources directory is two parents up + `Resources/<subdir>`. On
+/// Linux the binary lives at `<prefix>/bin/highbeam` and resources at
+/// `<prefix>/share/highbeam/<subdir>` (works for /usr, /usr/local, ~/.local,
+/// and any tarball-relocated PREFIX). When the binary lives anywhere else
+/// (`target/release/high-beam`, `cargo run`, `cargo install`'d into
+/// `~/.cargo/bin`), the computed path won't exist and we return `None`.
+fn bundled_resource_dir(subdir: &str) -> Option<PathBuf> {
     let exe = std::env::current_exe().ok()?;
-    // macOS `.app`: exe at Contents/MacOS/high-beam, plugins at
-    // Contents/Resources/plugins.
-    // Linux: exe at <prefix>/bin/highbeam, plugins at
-    // <prefix>/share/highbeam/plugins (works for /usr, /usr/local, ~/.local,
-    // and any tarball-relocated PREFIX).
     #[cfg(target_os = "macos")]
-    let candidate = exe.parent()?.parent()?.join("Resources").join("plugins");
+    let candidate = exe.parent()?.parent()?.join("Resources").join(subdir);
     #[cfg(not(target_os = "macos"))]
-    let candidate = exe.parent()?.parent()?.join("share").join("highbeam").join("plugins");
+    let candidate = exe.parent()?.parent()?.join("share").join("highbeam").join(subdir);
 
     candidate.is_dir().then_some(candidate)
 }
@@ -133,6 +180,30 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
     }
 
     Ok(())
+}
+
+/// Copy every file directly under `src` with the given extension into `dst`,
+/// skipping any whose name already exists there. Returns how many files were
+/// copied. Non-recursive — the themes dir is flat. The skip-existing rule is
+/// what makes theme seeding safe to run on every launch.
+fn copy_missing_files(src: &Path, dst: &Path, extension: &str) -> io::Result<usize> {
+    let copied = fs::read_dir(src)?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.is_file() && path.extension().and_then(|e| e.to_str()) == Some(extension))
+        .filter_map(|from| {
+            let to = dst.join(from.file_name()?);
+
+            if to.exists() {
+                return None;
+            }
+
+            Some(fs::copy(&from, &to).map(|_| ()))
+        })
+        .collect::<io::Result<Vec<()>>>()?
+        .len();
+
+    Ok(copied)
 }
 
 #[cfg(test)]
@@ -185,6 +256,35 @@ mod tests {
 
         assert_eq!(fs::read(dst.join("new.txt")).unwrap(), b"new");
         assert_eq!(fs::read(dst.join("preexisting.txt")).unwrap(), b"keep");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn copy_missing_files_skips_existing_and_filters_extension() {
+        // Theme seeding must add new shipped themes without clobbering a
+        // file the user already edited, and ignore non-theme files.
+        let root = fresh_tmp("copy-missing");
+        let src = root.join("src");
+        let dst = root.join("dst");
+        fs::create_dir_all(&src).unwrap();
+        fs::create_dir_all(&dst).unwrap();
+        fs::write(src.join("new.toml"), b"new").unwrap();
+        fs::write(src.join("edited.toml"), b"shipped").unwrap();
+        fs::write(src.join("README.md"), b"ignore me").unwrap();
+        // Pre-existing, user-edited copy that must survive untouched.
+        fs::write(dst.join("edited.toml"), b"user edit").unwrap();
+
+        let copied = copy_missing_files(&src, &dst, "toml").expect("copy");
+
+        assert_eq!(copied, 1, "only the missing .toml is copied");
+        assert_eq!(fs::read(dst.join("new.toml")).unwrap(), b"new");
+        assert_eq!(
+            fs::read(dst.join("edited.toml")).unwrap(),
+            b"user edit",
+            "existing file untouched"
+        );
+        assert!(!dst.join("README.md").exists(), "non-toml ignored");
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/bundle_install.rs
+++ b/src/bundle_install.rs
@@ -15,6 +15,8 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
+use crate::logging::LogErr;
+
 /// Install bundled default plugins into the user's plugin directory if the
 /// directory is empty or absent. Errors are logged and swallowed — a failed
 /// install must not prevent the daemon from booting.
@@ -186,25 +188,36 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
 /// skipping any whose name already exists there. Returns how many files were
 /// copied. Non-recursive — the themes dir is flat. The skip-existing rule is
 /// what makes theme seeding safe to run on every launch.
+///
+/// A per-file copy failure is logged and skipped so one unwritable file can't
+/// abort the rest of the seed; only failing to read `src` returns `Err`.
 fn copy_missing_files(src: &Path, dst: &Path, extension: &str) -> io::Result<usize> {
-    fs::read_dir(src)?
+    let copied = fs::read_dir(src)?
         .filter_map(Result::ok)
         .map(|entry| entry.path())
         .filter(|path| path.is_file() && path.extension().and_then(|e| e.to_str()) == Some(extension))
-        .try_fold(0_usize, |copied, from| {
+        .fold(0_usize, |copied, from| {
             let Some(name) = from.file_name() else {
-                return Ok(copied);
+                return copied;
             };
             let to = dst.join(name);
 
             if to.exists() {
-                return Ok(copied);
+                return copied;
             }
 
-            fs::copy(&from, &to)?;
+            // Log-and-skip so one unwritable file can't abort the rest. The
+            // paths go in the context since `io::Error` alone won't name them.
+            let context = format!(
+                "bundle-install: theme copy {} -> {} failed; skipping",
+                from.display(),
+                to.display()
+            );
 
-            Ok(copied + 1)
-        })
+            fs::copy(&from, &to).log_warn(&context).map_or(copied, |_| copied + 1)
+        });
+
+    Ok(copied)
 }
 
 #[cfg(test)]

--- a/src/bundle_install.rs
+++ b/src/bundle_install.rs
@@ -187,23 +187,24 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
 /// copied. Non-recursive — the themes dir is flat. The skip-existing rule is
 /// what makes theme seeding safe to run on every launch.
 fn copy_missing_files(src: &Path, dst: &Path, extension: &str) -> io::Result<usize> {
-    let copied = fs::read_dir(src)?
+    fs::read_dir(src)?
         .filter_map(Result::ok)
         .map(|entry| entry.path())
         .filter(|path| path.is_file() && path.extension().and_then(|e| e.to_str()) == Some(extension))
-        .filter_map(|from| {
-            let to = dst.join(from.file_name()?);
+        .try_fold(0_usize, |copied, from| {
+            let Some(name) = from.file_name() else {
+                return Ok(copied);
+            };
+            let to = dst.join(name);
 
             if to.exists() {
-                return None;
+                return Ok(copied);
             }
 
-            Some(fs::copy(&from, &to).map(|_| ()))
-        })
-        .collect::<io::Result<Vec<()>>>()?
-        .len();
+            fs::copy(&from, &to)?;
 
-    Ok(copied)
+            Ok(copied + 1)
+        })
 }
 
 #[cfg(test)]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -72,9 +72,7 @@ pub fn run(options: Options) -> Result<(), Box<dyn Error>> {
         bundle_install::install_default_plugins_if_needed();
     }
 
-    // Themes seed independently of the plugins-dir override — the theme
-    // selector reads the platform themes dir regardless of where plugins
-    // are loaded from.
+    // Independent of the plugins-dir override — themes live in the config dir.
     bundle_install::install_default_themes_if_needed();
 
     // Pin the winit backend explicitly — we rely on it for monitor enumeration
@@ -95,10 +93,8 @@ pub fn run(options: Options) -> Result<(), Box<dyn Error>> {
     // we register with the OS.
     let hotkey_spec = settings_for_ui.global().hotkey.clone();
 
-    // `RwLock` so the settings UI can swap the active theme (on pick / reload)
-    // while the watcher thread reads it; `Arc` so the watcher holds a clone for
-    // the daemon's lifetime. Reads dominate (every appearance flip / repaint),
-    // writes are rare (user picks a theme), so `RwLock` over `Mutex`.
+    // Swapped on pick/reload, read on every repaint — hence `RwLock`, shared
+    // with the appearance watcher via `Arc`.
     let theme = Arc::new(RwLock::new(Theme::load_named(settings_for_ui.theme())));
     {
         let theme = theme.read().expect("theme lock");

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5,7 +5,7 @@
 use std::error::Error;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::thread;
 
 use slint::ComponentHandle;
@@ -50,6 +50,12 @@ pub struct Options {
 /// Returns an error if the Slint backend fails to initialize, the window
 /// fails to construct, the unix socket can't be bound (e.g. another daemon
 /// is already running), or the event loop reports a runtime error.
+///
+/// # Panics
+///
+/// Panics if the active-theme `RwLock` is poisoned — a previous panic while
+/// holding it corrupted the shared theme and painting from it would risk
+/// rendering garbage.
 // reason: `Options` is a config struct created by the caller and consumed
 // here; by-value is more ergonomic than forcing the caller to keep it alive.
 #[allow(clippy::needless_pass_by_value)]
@@ -65,6 +71,11 @@ pub fn run(options: Options) -> Result<(), Box<dyn Error>> {
     if options.plugins_dir.is_none() {
         bundle_install::install_default_plugins_if_needed();
     }
+
+    // Themes seed independently of the plugins-dir override — the theme
+    // selector reads the platform themes dir regardless of where plugins
+    // are loaded from.
+    bundle_install::install_default_themes_if_needed();
 
     // Pin the winit backend explicitly — we rely on it for monitor enumeration
     // and focus events; a default-backend swap would otherwise fail opaquely.
@@ -84,12 +95,18 @@ pub fn run(options: Options) -> Result<(), Box<dyn Error>> {
     // we register with the OS.
     let hotkey_spec = settings_for_ui.global().hotkey.clone();
 
-    // Arc so the watcher thread can hold a clone for the daemon's lifetime.
-    let theme = Arc::new(Theme::load_or_default());
-    window::apply_theme(
-        &window,
-        theme.variant_for(settings_for_ui.theme_mode(), os_appearance::current()),
-    );
+    // `RwLock` so the settings UI can swap the active theme (on pick / reload)
+    // while the watcher thread reads it; `Arc` so the watcher holds a clone for
+    // the daemon's lifetime. Reads dominate (every appearance flip / repaint),
+    // writes are rare (user picks a theme), so `RwLock` over `Mutex`.
+    let theme = Arc::new(RwLock::new(Theme::load_named(settings_for_ui.theme())));
+    {
+        let theme = theme.read().expect("theme lock");
+        window::apply_theme(
+            &window,
+            theme.variant_for(settings_for_ui.theme_mode(), os_appearance::current()),
+        );
+    }
 
     let settings_controller = SettingsController::new(manifests, settings_for_ui);
 
@@ -105,6 +122,7 @@ pub fn run(options: Options) -> Result<(), Box<dyn Error>> {
             let mode = controller.theme_mode();
             slint::invoke_from_event_loop(move || {
                 if let Some(w) = weak.upgrade() {
+                    let theme = theme.read().expect("theme lock");
                     window::apply_theme(&w, theme.variant_for(mode, appearance));
                 }
             })

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -69,8 +69,8 @@ pub fn socket_path() -> io::Result<PathBuf> {
     }
 }
 
-/// Platform-specific config directory used for `theme.toml` and other
-/// user-edited settings.
+/// Platform-specific config directory used for `settings.toml`, the
+/// `themes/` folder, and other user-edited settings.
 ///
 /// - macOS: `~/Library/Application Support/high-beam/`
 /// - Linux: `$XDG_CONFIG_HOME/high-beam/` (default `~/.config/high-beam/`)
@@ -97,6 +97,14 @@ pub(crate) fn data_dir() -> Option<PathBuf> {
 /// first-launch bundle-seed lay plugins here.
 pub(crate) fn plugins_dir() -> Option<PathBuf> {
     data_dir().map(|d| d.join("plugins"))
+}
+
+/// Per-user themes directory under [`config_dir`]. The theme selector lists
+/// the `*.toml` files here; the first-launch bundle-seed lays the shipped
+/// themes in. Lives under the config dir (not data) because these are
+/// user-editable like `settings.toml`.
+pub(crate) fn themes_dir() -> Option<PathBuf> {
+    config_dir().ok().map(|d| d.join("themes"))
 }
 
 /// Platform-specific cache directory. macOS: `~/Library/Caches/high-beam/`;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -40,6 +40,11 @@ pub const DEFAULT_ALT_ACTION_MODIFIER: &str = "Alt";
 /// default at load time.
 pub const ALT_ACTION_MODIFIER_CHOICES: &[&str] = &["Alt", "Shift", "Cmd", "Ctrl"];
 
+/// Reserved theme name that selects the in-Rust builtin theme rather than a
+/// file in the themes dir. Kept here so the loader, the settings UI, and the
+/// disk-omission check all agree on the spelling.
+pub const DEFAULT_THEME: &str = "default";
+
 /// User-edited launcher state.
 ///
 /// The on-disk shape is the `SettingsFile` TOML schema (private, below);
@@ -85,6 +90,12 @@ pub struct GlobalSettings {
     /// silently degrade to `Auto` — see the `From<&str>` impl on
     /// [`ThemeMode`].
     pub theme_mode: ThemeMode,
+    /// Which theme the launcher paints. The reserved value [`DEFAULT_THEME`]
+    /// selects the in-Rust builtin; any other value names a `<stem>.toml`
+    /// file in the themes dir (see [`crate::paths::themes_dir`]). A missing
+    /// or malformed file falls back to the builtin at load time, so a stale
+    /// name on disk never blocks startup.
+    pub theme: String,
 }
 
 /// Saved outer-position of the launcher window, in physical pixels relative
@@ -110,6 +121,7 @@ impl Default for GlobalSettings {
             query_history_max_entries: DEFAULT_QUERY_HISTORY_MAX_ENTRIES,
             alt_action_modifier: DEFAULT_ALT_ACTION_MODIFIER.to_owned(),
             theme_mode: ThemeMode::default(),
+            theme: DEFAULT_THEME.to_owned(),
         }
     }
 }
@@ -243,6 +255,7 @@ impl Settings {
                 .theme_mode
                 .as_deref()
                 .map_or(ThemeMode::default(), ThemeMode::from);
+            let theme = raw_global.theme.unwrap_or_else(|| DEFAULT_THEME.to_owned());
 
             GlobalSettings {
                 hotkey: raw_global.hotkey.unwrap_or_else(|| DEFAULT_HOTKEY.to_owned()),
@@ -250,6 +263,7 @@ impl Settings {
                 query_history_max_entries: max_entries,
                 alt_action_modifier: alt_mod,
                 theme_mode,
+                theme,
             }
         };
 
@@ -311,6 +325,11 @@ impl Settings {
                 ThemeMode::Auto => None,
                 mode => Some(mode.as_str().to_owned()),
             };
+            let theme = if self.global.theme == DEFAULT_THEME {
+                None
+            } else {
+                Some(self.global.theme.clone())
+            };
 
             Some(GlobalFile {
                 hotkey: Some(self.global.hotkey.clone()),
@@ -322,6 +341,7 @@ impl Settings {
                 },
                 alt_action_modifier: alt_mod,
                 theme_mode,
+                theme,
             })
         };
         let file = SettingsFile { global, plugins };
@@ -478,6 +498,26 @@ impl Settings {
         self.global.theme_mode = ThemeMode::from(value);
     }
 
+    /// User's selected theme — the reserved [`DEFAULT_THEME`] for the
+    /// builtin, or a `<stem>.toml` file name in the themes dir.
+    #[must_use]
+    pub fn theme(&self) -> &str {
+        &self.global.theme
+    }
+
+    /// Replace the selected theme. Trimmed before storing; an empty value
+    /// resets to [`DEFAULT_THEME`] so a stray pick can't persist a blank
+    /// name the loader would then fail to resolve.
+    pub fn set_theme(&mut self, value: &str) {
+        let trimmed = value.trim();
+
+        self.global.theme = if trimmed.is_empty() {
+            DEFAULT_THEME.to_owned()
+        } else {
+            trimmed.to_owned()
+        };
+    }
+
     /// Set the global hotkey accelerator string. Trimmed before storing so
     /// `"Shift+Space "` from a stray `TextInput` doesn't fail the parser later.
     pub fn set_hotkey(&mut self, hotkey: &str) {
@@ -519,6 +559,8 @@ struct GlobalFile {
     alt_action_modifier: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     theme_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    theme: Option<String>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -788,6 +830,62 @@ mod tests {
         let mut s = Settings::default();
         s.set_theme_mode("nonsense");
         assert_eq!(s.theme_mode(), ThemeMode::Auto);
+    }
+
+    #[test]
+    fn theme_round_trips_through_toml() {
+        let mut s = Settings::default();
+        s.set_theme("dracula");
+        let text = s.to_toml();
+        assert!(text.contains("theme = \"dracula\""), "got: {text}");
+
+        let loaded = Settings::from_toml(&text).expect("parse");
+        assert_eq!(loaded.theme(), "dracula");
+    }
+
+    #[test]
+    fn theme_default_omitted_from_disk() {
+        // Round-trip a named theme back to "default" to exercise the
+        // `theme == DEFAULT_THEME => None` write branch — setting default on
+        // a fresh Settings is a no-op and wouldn't catch a regression where
+        // the reserved name leaks back to disk.
+        let mut s = Settings::default();
+        s.set_theme("nord");
+        s.set_hotkey("Cmd+K");
+        let named_text = s.to_toml();
+        assert!(
+            named_text.contains("theme = \"nord\""),
+            "named must be written: {named_text}"
+        );
+
+        s.set_theme(DEFAULT_THEME);
+        let default_text = s.to_toml();
+        assert!(
+            !default_text.contains("theme ="),
+            "default must be omitted on next write: {default_text}",
+        );
+    }
+
+    #[test]
+    fn set_theme_trims_and_blank_resets_to_default() {
+        let mut s = Settings::default();
+        s.set_theme("  tokyo-night  ");
+        assert_eq!(s.theme(), "tokyo-night", "surrounding whitespace trimmed");
+
+        s.set_theme("   ");
+        assert_eq!(s.theme(), DEFAULT_THEME, "blank resets to the builtin");
+    }
+
+    #[test]
+    fn theme_defaults_when_absent() {
+        // No `[global]` at all, and a `[global]` without `theme`, both fall
+        // back to the builtin rather than an empty string the loader would
+        // choke on.
+        let s = Settings::from_toml("").expect("empty parses");
+        assert_eq!(s.theme(), DEFAULT_THEME);
+
+        let s = Settings::from_toml("[global]\n").expect("parse");
+        assert_eq!(s.theme(), DEFAULT_THEME);
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -845,10 +845,8 @@ mod tests {
 
     #[test]
     fn theme_default_omitted_from_disk() {
-        // Round-trip a named theme back to "default" to exercise the
-        // `theme == DEFAULT_THEME => None` write branch — setting default on
-        // a fresh Settings is a no-op and wouldn't catch a regression where
-        // the reserved name leaks back to disk.
+        // Round-trip a named theme back to default — a fresh-default no-op
+        // wouldn't catch the reserved name leaking back to disk.
         let mut s = Settings::default();
         s.set_theme("nord");
         s.set_hotkey("Cmd+K");
@@ -878,9 +876,7 @@ mod tests {
 
     #[test]
     fn theme_defaults_when_absent() {
-        // No `[global]` at all, and a `[global]` without `theme`, both fall
-        // back to the builtin rather than an empty string the loader would
-        // choke on.
+        // Absent must yield the builtin, not an empty string the loader chokes on.
         let s = Settings::from_toml("").expect("empty parses");
         assert_eq!(s.theme(), DEFAULT_THEME);
 

--- a/src/settings_ui.rs
+++ b/src/settings_ui.rs
@@ -114,6 +114,7 @@ impl SettingsController {
         // Populate before the user first opens settings.
         self.refresh_slots(window);
         self.refresh_global(window);
+        self.refresh_themes(window);
 
         let ctrl = self.clone();
         let weak = window.as_weak();
@@ -123,6 +124,9 @@ impl SettingsController {
                 ctrl.refresh_slots(&w);
                 ctrl.refresh_options(&w);
                 ctrl.refresh_global(&w);
+                // Rescan the themes dir on open so a file dropped in or
+                // removed since last open shows up.
+                ctrl.refresh_themes(&w);
             }
         });
 
@@ -250,15 +254,15 @@ impl SettingsController {
     }
 
     fn refresh_global(&self, window: &QueryWindow) {
-        // Snapshot under the lock, then release it before the themes-dir scan
-        // in `refresh_theme_choices` — no I/O while holding the settings lock.
-        let (hotkey, alt_mod, theme_mode, theme_name) = {
+        // Snapshot under the lock, then release it before pushing into Slint.
+        // The theme dropdown is refreshed separately in `refresh_themes` (it
+        // does a disk scan we don't want on every global mutation).
+        let (hotkey, alt_mod, theme_mode) = {
             let settings = self.inner.settings.lock().expect("settings lock");
             (
                 settings.global().hotkey.clone(),
                 settings.alt_action_modifier().to_owned(),
                 settings.theme_mode(),
-                settings.theme().to_owned(),
             )
         };
 
@@ -266,18 +270,34 @@ impl SettingsController {
         window.set_alt_action_modifier(SharedString::from(alt_mod.as_str()));
         window.set_alt_action_modifier_flag(SharedString::from(slint_flag_for_modifier(&alt_mod)));
         window.set_theme_mode(SharedString::from(theme_mode_label(theme_mode)));
-
-        Self::refresh_theme_choices(window, &theme_name);
     }
 
-    /// Rebuild the theme dropdown: model is the reserved `default` followed by
-    /// the themes-dir `*.toml` stems, and the index is derived from the saved
-    /// selection (falling back to `default` when the saved name is gone — e.g.
-    /// the user deleted the file). Called on every settings open, so a file
-    /// dropped in or removed shows up without a restart.
+    /// Rebuild the theme dropdown from the themes dir and the saved selection.
+    /// Reads the current name under the settings lock, then scans the dir
+    /// (outside the lock — no I/O while holding it). Split from
+    /// [`Self::refresh_global`] so the disk scan only runs when the theme
+    /// surface actually changes (settings open, theme pick), not on every
+    /// unrelated global mutation (hotkey, alt-modifier, theme-mode).
+    fn refresh_themes(&self, window: &QueryWindow) {
+        let selected = self.theme();
+
+        Self::refresh_theme_choices(window, &selected);
+    }
+
+    /// Build the dropdown model — the reserved `default` followed by the
+    /// themes-dir `*.toml` stems — and point the index at the saved selection
+    /// (falling back to `default` when the saved name is gone, e.g. the user
+    /// deleted the file). A stem literally named `default` is dropped so the
+    /// reserved entry stays unique; [`crate::theme::Theme::load_named`] maps
+    /// `default` to the builtin regardless, so such a file is unreachable by
+    /// design.
     fn refresh_theme_choices(window: &QueryWindow, selected: &str) {
         let names: Vec<String> = std::iter::once(crate::settings::DEFAULT_THEME.to_owned())
-            .chain(crate::theme::available_theme_names())
+            .chain(
+                crate::theme::available_theme_names()
+                    .into_iter()
+                    .filter(|name| name != crate::settings::DEFAULT_THEME),
+            )
             .collect();
         let index = names.iter().position(|name| name == selected).unwrap_or(0);
         let model: Vec<SharedString> = names.into_iter().map(SharedString::from).collect();
@@ -331,7 +351,9 @@ impl SettingsController {
             ctrl.swap_active_theme(&theme_for_select);
 
             if let Some(w) = weak.upgrade() {
-                ctrl.refresh_global(&w);
+                // Resync the dropdown index to the pick; the other global
+                // fields are untouched, so no full `refresh_global`.
+                ctrl.refresh_themes(&w);
                 Self::apply_active_theme(&w, &theme_for_select, ctrl.theme_mode());
             }
         });

--- a/src/settings_ui.rs
+++ b/src/settings_ui.rs
@@ -106,10 +106,8 @@ impl SettingsController {
 
     /// Wire every settings callback on the given window. Idempotent; call
     /// once per window. `theme` is the live active theme shared with the
-    /// daemon's appearance watcher: the theme-mode handler re-applies its
-    /// variant on pick, and the theme selector / reload swap the inner
-    /// `Theme` so the change takes effect without an OS-appearance flip or a
-    /// restart.
+    /// daemon's appearance watcher; the selector / reload swap it in place so
+    /// picks apply without a restart.
     pub fn wire(&self, window: &QueryWindow, theme: Arc<RwLock<Theme>>) {
         // Populate before the user first opens settings.
         self.refresh_slots(window);
@@ -124,8 +122,7 @@ impl SettingsController {
                 ctrl.refresh_slots(&w);
                 ctrl.refresh_options(&w);
                 ctrl.refresh_global(&w);
-                // Rescan the themes dir on open so a file dropped in or
-                // removed since last open shows up.
+                // Rescan so files added/removed since last open show up.
                 ctrl.refresh_themes(&w);
             }
         });
@@ -254,9 +251,8 @@ impl SettingsController {
     }
 
     fn refresh_global(&self, window: &QueryWindow) {
-        // Snapshot under the lock, then release it before pushing into Slint.
-        // The theme dropdown is refreshed separately in `refresh_themes` (it
-        // does a disk scan we don't want on every global mutation).
+        // Theme dropdown is refreshed separately (`refresh_themes`) to keep its
+        // disk scan off every global mutation.
         let (hotkey, alt_mod, theme_mode) = {
             let settings = self.inner.settings.lock().expect("settings lock");
             (
@@ -272,25 +268,19 @@ impl SettingsController {
         window.set_theme_mode(SharedString::from(theme_mode_label(theme_mode)));
     }
 
-    /// Rebuild the theme dropdown from the themes dir and the saved selection.
-    /// Reads the current name under the settings lock, then scans the dir
-    /// (outside the lock — no I/O while holding it). Split from
-    /// [`Self::refresh_global`] so the disk scan only runs when the theme
-    /// surface actually changes (settings open, theme pick), not on every
-    /// unrelated global mutation (hotkey, alt-modifier, theme-mode).
+    /// Reads the selection, then scans the themes dir outside the lock. Split
+    /// from [`Self::refresh_global`] to keep the disk scan off unrelated
+    /// global mutations.
     fn refresh_themes(&self, window: &QueryWindow) {
         let selected = self.theme();
 
         Self::refresh_theme_choices(window, &selected);
     }
 
-    /// Build the dropdown model — the reserved `default` followed by the
-    /// themes-dir `*.toml` stems — and point the index at the saved selection
-    /// (falling back to `default` when the saved name is gone, e.g. the user
-    /// deleted the file). A stem literally named `default` is dropped so the
-    /// reserved entry stays unique; [`crate::theme::Theme::load_named`] maps
-    /// `default` to the builtin regardless, so such a file is unreachable by
-    /// design.
+    /// Model is the reserved `default` plus the themes-dir stems; the index
+    /// points at `selected`, falling back to `default` when its file is gone.
+    /// A stem named `default` is dropped — [`crate::theme::Theme::load_named`]
+    /// maps that name to the builtin, so such a file is unreachable anyway.
     fn refresh_theme_choices(window: &QueryWindow, selected: &str) {
         let names: Vec<String> = std::iter::once(crate::settings::DEFAULT_THEME.to_owned())
             .chain(
@@ -324,10 +314,8 @@ impl SettingsController {
         self.queue_persist();
     }
 
-    /// Hook the theme-mode dropdown, the theme selector, and the reload
-    /// button into `window`. Split from [`Self::wire`] to keep it under the
-    /// line cap. All three re-apply the active theme immediately rather than
-    /// waiting for the next OS-appearance poll tick.
+    /// Theme-mode, theme selector, and reload. All re-apply immediately rather
+    /// than waiting for the next OS-appearance poll tick.
     fn wire_theme_controls(&self, window: &QueryWindow, theme: Arc<RwLock<Theme>>) {
         let ctrl = self.clone();
         let weak = window.as_weak();
@@ -351,8 +339,6 @@ impl SettingsController {
             ctrl.swap_active_theme(&theme_for_select);
 
             if let Some(w) = weak.upgrade() {
-                // Resync the dropdown index to the pick; the other global
-                // fields are untouched, so no full `refresh_global`.
                 ctrl.refresh_themes(&w);
                 Self::apply_active_theme(&w, &theme_for_select, ctrl.theme_mode());
             }
@@ -362,8 +348,7 @@ impl SettingsController {
         let weak = window.as_weak();
 
         window.on_reload_theme(move || {
-            // Re-read the file from disk in case the user edited it, then
-            // re-apply. No settings write — the selection didn't change.
+            // No settings write — only picks up on-disk edits to the selection.
             ctrl.swap_active_theme(&theme);
 
             if let Some(w) = weak.upgrade() {

--- a/src/settings_ui.rs
+++ b/src/settings_ui.rs
@@ -8,11 +8,13 @@
 //! state is independent of the query/results state.
 
 use std::sync::mpsc;
-use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::sync::{Arc, Mutex, OnceLock, RwLock, Weak};
 use std::thread;
 
 use serde_json::Value as JsonValue;
 use slint::{ComponentHandle, ModelRc, SharedString, VecModel};
+
+use crate::theme::Theme;
 
 use crate::QueryWindow;
 use crate::daemon::HotkeyRegistration;
@@ -103,9 +105,12 @@ impl SettingsController {
     }
 
     /// Wire every settings callback on the given window. Idempotent; call
-    /// once per window. `theme` lets the theme-mode handler re-apply the
-    /// variant on pick, without waiting for the next OS-appearance flip.
-    pub fn wire(&self, window: &QueryWindow, theme: Arc<crate::theme::Theme>) {
+    /// once per window. `theme` is the live active theme shared with the
+    /// daemon's appearance watcher: the theme-mode handler re-applies its
+    /// variant on pick, and the theme selector / reload swap the inner
+    /// `Theme` so the change takes effect without an OS-appearance flip or a
+    /// restart.
+    pub fn wire(&self, window: &QueryWindow, theme: Arc<RwLock<Theme>>) {
         // Populate before the user first opens settings.
         self.refresh_slots(window);
         self.refresh_global(window);
@@ -231,7 +236,7 @@ impl SettingsController {
             }
         });
 
-        self.wire_theme_mode_select(window, theme);
+        self.wire_theme_controls(window, theme);
 
         let weak = window.as_weak();
         window.on_select_global(move || {
@@ -245,13 +250,40 @@ impl SettingsController {
     }
 
     fn refresh_global(&self, window: &QueryWindow) {
-        let settings = self.inner.settings.lock().expect("settings lock");
-        window.set_hotkey_value(SharedString::from(settings.global().hotkey.as_str()));
-        window.set_alt_action_modifier(SharedString::from(settings.alt_action_modifier()));
-        window.set_alt_action_modifier_flag(SharedString::from(slint_flag_for_modifier(
-            settings.alt_action_modifier(),
-        )));
-        window.set_theme_mode(SharedString::from(theme_mode_label(settings.theme_mode())));
+        // Snapshot under the lock, then release it before the themes-dir scan
+        // in `refresh_theme_choices` — no I/O while holding the settings lock.
+        let (hotkey, alt_mod, theme_mode, theme_name) = {
+            let settings = self.inner.settings.lock().expect("settings lock");
+            (
+                settings.global().hotkey.clone(),
+                settings.alt_action_modifier().to_owned(),
+                settings.theme_mode(),
+                settings.theme().to_owned(),
+            )
+        };
+
+        window.set_hotkey_value(SharedString::from(hotkey.as_str()));
+        window.set_alt_action_modifier(SharedString::from(alt_mod.as_str()));
+        window.set_alt_action_modifier_flag(SharedString::from(slint_flag_for_modifier(&alt_mod)));
+        window.set_theme_mode(SharedString::from(theme_mode_label(theme_mode)));
+
+        Self::refresh_theme_choices(window, &theme_name);
+    }
+
+    /// Rebuild the theme dropdown: model is the reserved `default` followed by
+    /// the themes-dir `*.toml` stems, and the index is derived from the saved
+    /// selection (falling back to `default` when the saved name is gone — e.g.
+    /// the user deleted the file). Called on every settings open, so a file
+    /// dropped in or removed shows up without a restart.
+    fn refresh_theme_choices(window: &QueryWindow, selected: &str) {
+        let names: Vec<String> = std::iter::once(crate::settings::DEFAULT_THEME.to_owned())
+            .chain(crate::theme::available_theme_names())
+            .collect();
+        let index = names.iter().position(|name| name == selected).unwrap_or(0);
+        let model: Vec<SharedString> = names.into_iter().map(SharedString::from).collect();
+
+        window.set_theme_names(ModelRc::new(VecModel::from(model)));
+        window.set_theme_index(i32::try_from(index).unwrap_or(0));
     }
 
     fn set_hotkey(&self, value: &str) {
@@ -272,23 +304,75 @@ impl SettingsController {
         self.queue_persist();
     }
 
-    /// Hook the theme-mode dropdown into `window`. Split from [`Self::wire`]
-    /// to keep it under the line cap.
-    fn wire_theme_mode_select(&self, window: &QueryWindow, theme: Arc<crate::theme::Theme>) {
+    /// Hook the theme-mode dropdown, the theme selector, and the reload
+    /// button into `window`. Split from [`Self::wire`] to keep it under the
+    /// line cap. All three re-apply the active theme immediately rather than
+    /// waiting for the next OS-appearance poll tick.
+    fn wire_theme_controls(&self, window: &QueryWindow, theme: Arc<RwLock<Theme>>) {
         let ctrl = self.clone();
         let weak = window.as_weak();
+        let theme_for_mode = Arc::clone(&theme);
+
         window.on_set_theme_mode(move |value| {
             ctrl.set_theme_mode(value.as_str());
 
             if let Some(w) = weak.upgrade() {
                 ctrl.refresh_global(&w);
-                // Re-apply now rather than waiting for the next poll tick.
-                crate::window::apply_theme(
-                    &w,
-                    theme.variant_for(ctrl.theme_mode(), crate::os_appearance::current()),
-                );
+                Self::apply_active_theme(&w, &theme_for_mode, ctrl.theme_mode());
             }
         });
+
+        let ctrl = self.clone();
+        let weak = window.as_weak();
+        let theme_for_select = Arc::clone(&theme);
+
+        window.on_set_theme(move |value| {
+            ctrl.set_theme(value.as_str());
+            ctrl.swap_active_theme(&theme_for_select);
+
+            if let Some(w) = weak.upgrade() {
+                ctrl.refresh_global(&w);
+                Self::apply_active_theme(&w, &theme_for_select, ctrl.theme_mode());
+            }
+        });
+
+        let ctrl = self.clone();
+        let weak = window.as_weak();
+
+        window.on_reload_theme(move || {
+            // Re-read the file from disk in case the user edited it, then
+            // re-apply. No settings write — the selection didn't change.
+            ctrl.swap_active_theme(&theme);
+
+            if let Some(w) = weak.upgrade() {
+                Self::apply_active_theme(&w, &theme, ctrl.theme_mode());
+            }
+        });
+    }
+
+    /// Replace the shared active theme with the user's current selection,
+    /// re-read from disk. Used by both the selector (after the settings write)
+    /// and the reload button.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the theme lock is poisoned — a previous panic while holding
+    /// it corrupted the shared state and continuing risks painting garbage.
+    fn swap_active_theme(&self, theme: &Arc<RwLock<Theme>>) {
+        let loaded = Theme::load_named(&self.theme());
+        *theme.write().expect("theme lock") = loaded;
+    }
+
+    /// Paint the active theme's variant for `mode` against the current system
+    /// appearance. Reads the shared theme under a read lock; the borrow can't
+    /// escape the guard, so the apply happens inside the locked scope.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the theme lock is poisoned. See [`Self::swap_active_theme`].
+    fn apply_active_theme(window: &QueryWindow, theme: &Arc<RwLock<Theme>>, mode: crate::theme::ThemeMode) {
+        let guard = theme.read().expect("theme lock");
+        crate::window::apply_theme(window, guard.variant_for(mode, crate::os_appearance::current()));
     }
 
     fn set_theme_mode(&self, value: &str) {
@@ -298,6 +382,26 @@ impl SettingsController {
         }
 
         self.queue_persist();
+    }
+
+    fn set_theme(&self, value: &str) {
+        {
+            let mut settings = self.inner.settings.lock().expect("settings lock");
+            settings.set_theme(value);
+        }
+
+        self.queue_persist();
+    }
+
+    /// The user's currently selected theme name (file stem or the reserved
+    /// default). Read when swapping / reloading the active theme.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the settings mutex is poisoned. See
+    /// [`Self::launcher_position`] for the rationale.
+    fn theme(&self) -> String {
+        self.inner.settings.lock().expect("settings lock").theme().to_owned()
     }
 
     /// Last saved launcher window origin, or `None` if the user has never
@@ -688,10 +792,10 @@ fn next_choice(current: &str, choices: &[String]) -> String {
     choices.get(next).cloned().unwrap_or_else(|| current.to_owned())
 }
 
-/// Title-cased label for the theme-mode pill in the settings UI.
+/// Title-cased label for the theme-mode dropdown in the settings UI.
 /// [`crate::theme::ThemeMode::as_str`] returns the lowercase on-disk
 /// spelling; this helper provides the display variant the user reads in
-/// the click-to-cycle row.
+/// the selector.
 fn theme_mode_label(mode: crate::theme::ThemeMode) -> &'static str {
     use crate::theme::ThemeMode;
     match mode {

--- a/src/settings_ui.rs
+++ b/src/settings_ui.rs
@@ -14,15 +14,15 @@ use std::thread;
 use serde_json::Value as JsonValue;
 use slint::{ComponentHandle, ModelRc, SharedString, VecModel};
 
-use crate::theme::Theme;
-
 use crate::QueryWindow;
 use crate::daemon::HotkeyRegistration;
 use crate::hotkey::{MOD_ALT, MOD_CONTROL, MOD_META, MOD_SHIFT, format_hotkey_spec, slint_flag_for_modifier};
 use crate::logging::LogErr;
 use crate::plugins::manifest::{Manifest, OptionDef, OptionKind};
-use crate::settings::{Settings, WindowPosition};
+use crate::settings::{DEFAULT_THEME, Settings, WindowPosition};
+use crate::theme::{Theme, ThemeMode, available_theme_names};
 use crate::ui::{PluginOption, PluginSlot};
+use crate::{os_appearance, window};
 
 /// Display metadata for a plugin, extracted from its manifest and handed to
 /// the settings view so the right pane can show a header.
@@ -282,12 +282,8 @@ impl SettingsController {
     /// A stem named `default` is dropped — [`crate::theme::Theme::load_named`]
     /// maps that name to the builtin, so such a file is unreachable anyway.
     fn refresh_theme_choices(window: &QueryWindow, selected: &str) {
-        let names: Vec<String> = std::iter::once(crate::settings::DEFAULT_THEME.to_owned())
-            .chain(
-                crate::theme::available_theme_names()
-                    .into_iter()
-                    .filter(|name| name != crate::settings::DEFAULT_THEME),
-            )
+        let names: Vec<String> = std::iter::once(DEFAULT_THEME.to_owned())
+            .chain(available_theme_names().into_iter().filter(|name| name != DEFAULT_THEME))
             .collect();
         let index = names.iter().position(|name| name == selected).unwrap_or(0);
         let model: Vec<SharedString> = names.into_iter().map(SharedString::from).collect();
@@ -377,9 +373,9 @@ impl SettingsController {
     /// # Panics
     ///
     /// Panics if the theme lock is poisoned. See [`Self::swap_active_theme`].
-    fn apply_active_theme(window: &QueryWindow, theme: &Arc<RwLock<Theme>>, mode: crate::theme::ThemeMode) {
+    fn apply_active_theme(window: &QueryWindow, theme: &Arc<RwLock<Theme>>, mode: ThemeMode) {
         let guard = theme.read().expect("theme lock");
-        crate::window::apply_theme(window, guard.variant_for(mode, crate::os_appearance::current()));
+        window::apply_theme(window, guard.variant_for(mode, os_appearance::current()));
     }
 
     fn set_theme_mode(&self, value: &str) {
@@ -507,7 +503,7 @@ impl SettingsController {
     /// Panics if the settings mutex is poisoned. See
     /// [`Self::launcher_position`] for the rationale.
     #[must_use]
-    pub fn theme_mode(&self) -> crate::theme::ThemeMode {
+    pub fn theme_mode(&self) -> ThemeMode {
         self.inner.settings.lock().expect("settings lock").theme_mode()
     }
 
@@ -803,8 +799,7 @@ fn next_choice(current: &str, choices: &[String]) -> String {
 /// [`crate::theme::ThemeMode::as_str`] returns the lowercase on-disk
 /// spelling; this helper provides the display variant the user reads in
 /// the selector.
-fn theme_mode_label(mode: crate::theme::ThemeMode) -> &'static str {
-    use crate::theme::ThemeMode;
+fn theme_mode_label(mode: ThemeMode) -> &'static str {
     match mode {
         ThemeMode::Auto => "Auto",
         ThemeMode::Dark => "Dark",

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,4 +1,12 @@
-//! User-editable theme loaded from `theme.toml` in the platform config dir.
+//! User-editable themes loaded by name from the platform themes dir.
+//!
+//! The user picks a theme by file stem in settings
+//! ([`crate::settings::Settings::theme`]); [`Theme::load_named`] resolves it
+//! to `<themes_dir>/<stem>.toml`. The reserved name
+//! [`crate::settings::DEFAULT_THEME`] (and any missing/malformed file) falls
+//! back to the in-Rust bundled yosemite-spotlight default, so a stale name
+//! never blocks startup. [`available_theme_names`] enumerates the dir for the
+//! settings dropdown.
 //!
 //! Each theme describes two appearances in one file. Top-level sections
 //! (`[colors]`, `[font]`, `[window]`) hold the base values; nested
@@ -8,15 +16,13 @@
 //! file still parses and looks identical in both modes.
 //!
 //! The user's [`crate::settings::Settings::theme_mode`] decides which
-//! variant `apply_theme` paints. Reload is restart-only; in `Auto` mode a
-//! background watcher (see [`crate::os_appearance`]) repaints on system
-//! flips without a restart.
+//! variant `apply_theme` paints. The settings UI swaps the active theme and
+//! re-applies live (no restart); in `Auto` mode a background watcher (see
+//! [`crate::os_appearance`]) repaints on system flips.
 //!
-//! Token surface mirrors `QueryWindow`'s `in-out` properties. Missing or
-//! malformed file falls back to the bundled yosemite-spotlight default.
+//! Token surface mirrors `QueryWindow`'s `in-out` properties.
 
 use std::fs;
-use std::path::PathBuf;
 
 use serde::Deserialize;
 use slint::Color;
@@ -168,21 +174,33 @@ impl Default for Window {
 }
 
 impl Theme {
-    /// Load the user's `theme.toml` from the platform config path. Missing
-    /// file → silent default; malformed → warning + default. A typo in the
-    /// theme must not prevent the daemon from starting.
+    /// Load the theme the user selected by `name`. The reserved
+    /// [`crate::settings::DEFAULT_THEME`] resolves to the in-Rust builtin; any
+    /// other name reads `<themes_dir>/<name>.toml`. Missing file → silent
+    /// default; unresolvable dir / malformed file → warning + default. A
+    /// stale name must not prevent the daemon from starting.
     #[must_use]
-    pub fn load_or_default() -> Self {
-        let Some(path) = default_theme_path() else {
-            tracing::warn!("theme: could not resolve config dir; using default");
+    pub fn load_named(name: &str) -> Self {
+        if name == crate::settings::DEFAULT_THEME {
+            return Self::default_bundled();
+        }
+
+        let Some(path) = paths::themes_dir().map(|dir| dir.join(format!("{name}.toml"))) else {
+            tracing::warn!(theme = name, "theme: could not resolve themes dir; using default");
+
             return Self::default_bundled();
         };
 
         match fs::read_to_string(&path) {
             Ok(text) => Self::from_toml_or_default(&text, &path),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Self::default_bundled(),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                tracing::warn!(theme = name, path = %path.display(), "theme: file not found; using default");
+
+                Self::default_bundled()
+            }
             Err(err) => {
-                tracing::warn!(path = %path.display(), %err, "theme: could not read; using default");
+                tracing::warn!(theme = name, path = %path.display(), %err, "theme: could not read; using default");
+
                 Self::default_bundled()
             }
         }
@@ -287,10 +305,28 @@ impl Theme {
     }
 }
 
-/// Path the daemon reads on startup. `None` when the project dir can't be
-/// resolved (no `$HOME` etc.).
-fn default_theme_path() -> Option<PathBuf> {
-    paths::config_dir().ok().map(|dir| dir.join("theme.toml"))
+/// Theme file stems available under the themes dir, sorted. The settings
+/// dropdown prepends [`crate::settings::DEFAULT_THEME`] to this; an
+/// unresolvable or empty dir yields an empty list (default still selectable).
+#[must_use]
+pub fn available_theme_names() -> Vec<String> {
+    let Some(dir) = paths::themes_dir() else {
+        return Vec::new();
+    };
+
+    let Ok(entries) = fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+
+    let mut names: Vec<String> = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|e| e.to_str()) == Some("toml"))
+        .filter_map(|path| path.file_stem().and_then(|s| s.to_str()).map(str::to_owned))
+        .collect();
+    names.sort_unstable();
+
+    names
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -690,6 +726,23 @@ mod tests {
             theme.variant_for(ThemeMode::Light, Appearance::Unspecified),
             &theme.light
         );
+    }
+
+    #[test]
+    fn load_named_default_returns_bundled() {
+        // The reserved name never touches disk — it's the in-Rust builtin.
+        assert_eq!(
+            Theme::load_named(crate::settings::DEFAULT_THEME),
+            Theme::default_bundled()
+        );
+    }
+
+    #[test]
+    fn load_named_missing_file_falls_back_to_default() {
+        // A name that resolves to a file the themes dir doesn't contain must
+        // degrade to the builtin rather than panic or block startup.
+        let theme = Theme::load_named("definitely-not-a-real-theme-xyz-9999");
+        assert_eq!(theme, Theme::default_bundled());
     }
 
     #[test]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -193,11 +193,8 @@ impl Theme {
 
         match fs::read_to_string(&path) {
             Ok(text) => Self::from_toml_or_default(&text, &path),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                tracing::warn!(theme = name, path = %path.display(), "theme: file not found; using default");
-
-                Self::default_bundled()
-            }
+            // Not-found (stale selection) and any other read error both fall
+            // back to the builtin — no behavioural split, so one arm.
             Err(err) => {
                 tracing::warn!(theme = name, path = %path.display(), %err, "theme: could not read; using default");
 

--- a/ui/query.slint
+++ b/ui/query.slint
@@ -55,8 +55,7 @@ export component QueryWindow inherits Window {
     // settings pane. Rust pushes the canonical value whenever the user
     // cycles it.
     in-out property <string> theme-mode: "Auto";
-    // Theme selector model + active index. Rust rebuilds both on every
-    // settings open (reserved "default" + themes-dir stems).
+    // Reserved "default" + themes-dir stems; rebuilt by Rust on settings open.
     in-out property <[string]> theme-names: ["default"];
     in-out property <int> theme-index: 0;
     // Resolved Slint-side flag name corresponding to the configured alt

--- a/ui/query.slint
+++ b/ui/query.slint
@@ -55,6 +55,10 @@ export component QueryWindow inherits Window {
     // settings pane. Rust pushes the canonical value whenever the user
     // cycles it.
     in-out property <string> theme-mode: "Auto";
+    // Theme selector model + active index. Rust rebuilds both on every
+    // settings open (reserved "default" + themes-dir stems).
+    in-out property <[string]> theme-names: ["default"];
+    in-out property <int> theme-index: 0;
     // Resolved Slint-side flag name corresponding to the configured alt
     // modifier, accounting for macOS's Cmd↔Ctrl flag swap. Rust pushes
     // it via `set-alt-action-modifier-flag` whenever the setting changes.
@@ -102,7 +106,7 @@ export component QueryWindow inherits Window {
     callback confirm-cancel();
 
     // Theme tokens. Defaults reproduce the bundled yosemite-spotlight theme so
-    // a missing theme.toml is byte-identical to the pre-theming build.
+    // the builtin `default` theme is byte-identical to the pre-theming build.
     in-out property <color> background-color: #ffffffea;
     in-out property <color> foreground-color: #1d1d1f;
     in-out property <color> muted-color: #86868b;
@@ -175,6 +179,8 @@ export component QueryWindow inherits Window {
     callback reset-hotkey-to-default();
     callback set-alt-action-modifier(string);
     callback set-theme-mode(string);
+    callback set-theme(string);
+    callback reload-theme();
     callback select-global();
     // Whether the hotkey field is currently listening for a key combo —
     // drives the prompt text + highlighted border in the global pane.
@@ -189,7 +195,7 @@ export component QueryWindow inherits Window {
     callback recenter-window();
     // Settings → Global → "Open config directory" — opens the platform
     // config dir in Finder / xdg-open. The directory holds settings.toml,
-    // theme.toml, and the per-plugin user-edited files.
+    // the themes/ folder, and the per-plugin user-edited files.
     callback open-config-dir();
 
     // Focus is managed explicitly via `focus-input()` which is invoked from
@@ -371,7 +377,10 @@ export component QueryWindow inherits Window {
             capturing-hotkey <=> root.capturing-hotkey;
             alt-action-modifier <=> root.alt-action-modifier;
             theme-mode <=> root.theme-mode;
+            theme-names: root.theme-names;
+            theme-index: root.theme-index;
 
+            background-color: root.background-color;
             foreground-color: root.foreground-color;
             muted-color: root.muted-color;
             highlight-color: root.highlight-color;
@@ -392,6 +401,8 @@ export component QueryWindow inherits Window {
             reset-hotkey-to-default => { root.reset-hotkey-to-default(); }
             set-alt-action-modifier(value) => { root.set-alt-action-modifier(value); }
             set-theme-mode(value) => { root.set-theme-mode(value); }
+            set-theme(value) => { root.set-theme(value); }
+            reload-theme => { root.reload-theme(); }
             select-global => { root.select-global(); }
             recenter-window => { root.recenter-window(); }
             open-config-dir => { root.open-config-dir(); }

--- a/ui/settings_view.slint
+++ b/ui/settings_view.slint
@@ -31,9 +31,8 @@ export component SettingsView {
     // controller normalises whatever the user wrote on disk, so this
     // property always carries one of those three exact strings.
     in-out property <string> theme-mode: "Auto";
-    // Theme selector: the dropdown options (reserved "default" + themes-dir
-    // stems) and the index of the active one. Both come from the controller
-    // on each settings open.
+    // Reserved "default" + themes-dir stems, and the active index — both from
+    // the controller on each settings open.
     in property <[string]> theme-names: ["default"];
     in property <int> theme-index: 0;
 
@@ -413,9 +412,7 @@ export component SettingsView {
                                 ThemedComboBox {
                                     width: 160px;
                                     model: ["Alt", "Shift", "Cmd", "Ctrl"];
-                                    // Index derived from the saved string; the
-                                    // controller refreshes that string on pick,
-                                    // so the display updates reactively.
+                                    // Derived from the string the controller refreshes on pick.
                                     current-index: root.alt-action-modifier == "Shift" ? 1
                                         : root.alt-action-modifier == "Cmd" ? 2
                                         : root.alt-action-modifier == "Ctrl" ? 3
@@ -466,9 +463,7 @@ export component SettingsView {
                                         root.set-theme(value);
                                     }
                                 }
-                                // Re-reads the selected theme file and applies
-                                // it — for picking up on-disk edits without a
-                                // restart or re-selecting.
+                                // Picks up on-disk edits without re-selecting.
                                 reload-touch := TouchArea {
                                     width: 110px;
                                     height: 28px;
@@ -511,9 +506,7 @@ export component SettingsView {
                                 ThemedComboBox {
                                     width: 160px;
                                     model: ["Auto", "Dark", "Light"];
-                                    // Index derived from the saved string; the
-                                    // controller refreshes it on pick, so the
-                                    // display updates reactively.
+                                    // Derived from the string the controller refreshes on pick.
                                     current-index: root.theme-mode == "Dark" ? 1
                                         : root.theme-mode == "Light" ? 2
                                         : 0;

--- a/ui/settings_view.slint
+++ b/ui/settings_view.slint
@@ -9,7 +9,8 @@
 // functions, which are forwarded through the `focus-rail` and
 // `sync-rail` public functions below.
 
-import { ScrollView, ComboBox } from "std-widgets.slint";
+import { ScrollView } from "std-widgets.slint";
+import { ThemedComboBox } from "themed_combobox.slint";
 import { PluginSlot, PluginOption } from "types.slint";
 
 export component SettingsView {
@@ -30,8 +31,14 @@ export component SettingsView {
     // controller normalises whatever the user wrote on disk, so this
     // property always carries one of those three exact strings.
     in-out property <string> theme-mode: "Auto";
+    // Theme selector: the dropdown options (reserved "default" + themes-dir
+    // stems) and the index of the active one. Both come from the controller
+    // on each settings open.
+    in property <[string]> theme-names: ["default"];
+    in property <int> theme-index: 0;
 
     // Theme tokens
+    in property <color> background-color;
     in property <color> foreground-color;
     in property <color> muted-color;
     in property <color> highlight-color;
@@ -57,6 +64,8 @@ export component SettingsView {
     callback sync-rail-selection();
     callback set-alt-action-modifier(string);
     callback set-theme-mode(string);
+    callback set-theme(string);
+    callback reload-theme();
 
     // Called by QueryWindow.show-settings() to give the rail immediate focus.
     public function focus-rail() {
@@ -401,19 +410,23 @@ export component SettingsView {
                             }
                             HorizontalLayout {
                                 alignment: start;
-                                ComboBox {
+                                ThemedComboBox {
                                     width: 160px;
                                     model: ["Alt", "Shift", "Cmd", "Ctrl"];
-                                    // Two-way: a plain `:` binding gets
-                                    // severed on the first user pick.
-                                    current-value <=> root.alt-action-modifier;
-                                    // ComboBoxBase keeps current-index
-                                    // independent of current-value, so
-                                    // derive it from the saved string.
+                                    // Index derived from the saved string; the
+                                    // controller refreshes that string on pick,
+                                    // so the display updates reactively.
                                     current-index: root.alt-action-modifier == "Shift" ? 1
                                         : root.alt-action-modifier == "Cmd" ? 2
                                         : root.alt-action-modifier == "Ctrl" ? 3
                                         : 0;
+                                    foreground-color: root.foreground-color;
+                                    background-color: root.background-color;
+                                    muted-color: root.muted-color;
+                                    border-color: root.border-color;
+                                    selection-color: root.selection-color;
+                                    highlight-color: root.highlight-color;
+                                    font-size: root.font-size-title;
                                     selected(value) => {
                                         root.set-alt-action-modifier(value);
                                     }
@@ -421,6 +434,64 @@ export component SettingsView {
                             }
                             Text {
                                 text: "Hold this key while pressing Enter or clicking a result to run its alternate action (when the plugin supplies one).";
+                                color: root.muted-color;
+                                font-size: root.font-size-subtitle;
+                                wrap: word-wrap;
+                            }
+                        }
+
+                        // Theme group: which theme + a manual reload.
+                        VerticalLayout {
+                            spacing: 4px;
+                            Text {
+                                text: "Theme";
+                                color: root.foreground-color;
+                                font-size: root.font-size-title;
+                            }
+                            HorizontalLayout {
+                                alignment: start;
+                                spacing: 8px;
+                                ThemedComboBox {
+                                    width: 200px;
+                                    model: root.theme-names;
+                                    current-index: root.theme-index;
+                                    foreground-color: root.foreground-color;
+                                    background-color: root.background-color;
+                                    muted-color: root.muted-color;
+                                    border-color: root.border-color;
+                                    selection-color: root.selection-color;
+                                    highlight-color: root.highlight-color;
+                                    font-size: root.font-size-title;
+                                    selected(value) => {
+                                        root.set-theme(value);
+                                    }
+                                }
+                                // Re-reads the selected theme file and applies
+                                // it — for picking up on-disk edits without a
+                                // restart or re-selecting.
+                                reload-touch := TouchArea {
+                                    width: 110px;
+                                    height: 28px;
+                                    clicked => {
+                                        root.reload-theme();
+                                    }
+                                    Rectangle {
+                                        background: root.selection-color;
+                                        border-radius: 4px;
+                                        border-width: 1px;
+                                        border-color: reload-touch.has-hover ? root.highlight-color : root.border-color;
+                                        Text {
+                                            text: "Reload theme";
+                                            color: root.foreground-color;
+                                            font-size: root.font-size-subtitle;
+                                            vertical-alignment: center;
+                                            horizontal-alignment: center;
+                                        }
+                                    }
+                                }
+                            }
+                            Text {
+                                text: "Themes live as .toml files in the themes/ folder of the config dir. \"default\" is the builtin. The list refreshes when you open Settings; Reload re-applies on-disk edits to the selected theme.";
                                 color: root.muted-color;
                                 font-size: root.font-size-subtitle;
                                 wrap: word-wrap;
@@ -437,18 +508,22 @@ export component SettingsView {
                             }
                             HorizontalLayout {
                                 alignment: start;
-                                ComboBox {
+                                ThemedComboBox {
                                     width: 160px;
                                     model: ["Auto", "Dark", "Light"];
-                                    // Two-way: a plain `:` binding gets
-                                    // severed on the first user pick.
-                                    current-value <=> root.theme-mode;
-                                    // ComboBoxBase keeps current-index
-                                    // independent of current-value, so
-                                    // derive it from the saved string.
+                                    // Index derived from the saved string; the
+                                    // controller refreshes it on pick, so the
+                                    // display updates reactively.
                                     current-index: root.theme-mode == "Dark" ? 1
                                         : root.theme-mode == "Light" ? 2
                                         : 0;
+                                    foreground-color: root.foreground-color;
+                                    background-color: root.background-color;
+                                    muted-color: root.muted-color;
+                                    border-color: root.border-color;
+                                    selection-color: root.selection-color;
+                                    highlight-color: root.highlight-color;
+                                    font-size: root.font-size-title;
                                     selected(value) => {
                                         root.set-theme-mode(value);
                                     }
@@ -489,7 +564,7 @@ export component SettingsView {
                                 }
                             }
                             Text {
-                                text: "Opens the platform config dir in Finder. Holds settings.toml, theme.toml, and per-plugin overrides.";
+                                text: "Opens the platform config dir in Finder. Holds settings.toml, the themes/ folder, and per-plugin overrides.";
                                 color: root.muted-color;
                                 font-size: root.font-size-subtitle;
                                 wrap: word-wrap;

--- a/ui/themed_combobox.slint
+++ b/ui/themed_combobox.slint
@@ -1,13 +1,8 @@
-// Theme-token-styled dropdown, used everywhere the settings view needs a
-// selector. The std-widgets `ComboBox` paints with Slint's backend style and
-// ignores our theme tokens, so we hand-roll one that takes the launcher
-// colors and font.
+// Token-styled dropdown — the std-widgets `ComboBox` ignores our theme colors.
 //
-// Presentational + index-driven: the caller supplies `model` and a one-way
-// `current-index` (derived from whatever it persists), and we emit
-// `selected(value)` on a pick. We never self-assign `current-index` — the
-// caller's binding stays intact and re-evaluates after it persists the new
-// value, so the display updates without any two-way plumbing here.
+// Index-driven and one-way: we never self-assign `current-index`, so the
+// caller's binding stays intact and re-evaluates after it persists the pick.
+// Display updates need no two-way plumbing.
 
 export component ThemedComboBox {
     in property <[string]> model;
@@ -52,7 +47,6 @@ export component ThemedComboBox {
                 overflow: elide;
             }
 
-            // Chevron, pushed to the trailing edge.
             Text {
                 text: "▾";
                 color: root.muted-color;

--- a/ui/themed_combobox.slint
+++ b/ui/themed_combobox.slint
@@ -1,0 +1,117 @@
+// Theme-token-styled dropdown, used everywhere the settings view needs a
+// selector. The std-widgets `ComboBox` paints with Slint's backend style and
+// ignores our theme tokens, so we hand-roll one that takes the launcher
+// colors and font.
+//
+// Presentational + index-driven: the caller supplies `model` and a one-way
+// `current-index` (derived from whatever it persists), and we emit
+// `selected(value)` on a pick. We never self-assign `current-index` — the
+// caller's binding stays intact and re-evaluates after it persists the new
+// value, so the display updates without any two-way plumbing here.
+
+export component ThemedComboBox {
+    in property <[string]> model;
+    in property <int> current-index: 0;
+
+    // Theme tokens — mirror the names used across the settings view.
+    in property <color> foreground-color;
+    in property <color> background-color;
+    in property <color> muted-color;
+    in property <color> border-color;
+    in property <color> selection-color;
+    in property <color> highlight-color;
+    in property <length> font-size: 14px;
+
+    callback selected(string);
+
+    // Guarded lookup so an empty model or stale index can't index out of
+    // range — Slint clamps nothing for us.
+    property <bool> index-valid: root.current-index >= 0 && root.current-index < root.model.length;
+    property <string> current-text: root.index-valid ? root.model[root.current-index] : "";
+
+    height: 28px;
+    min-width: 160px;
+
+    field := Rectangle {
+        background: root.muted-color.with-alpha(0.08);
+        border-radius: 4px;
+        border-width: 1px;
+        border-color: touch.has-hover ? root.highlight-color : root.border-color;
+
+        HorizontalLayout {
+            padding-left: 8px;
+            padding-right: 8px;
+            spacing: 6px;
+
+            Text {
+                text: root.current-text;
+                color: root.foreground-color;
+                font-size: root.font-size;
+                vertical-alignment: center;
+                horizontal-alignment: left;
+                overflow: elide;
+            }
+
+            // Chevron, pushed to the trailing edge.
+            Text {
+                text: "▾";
+                color: root.muted-color;
+                font-size: root.font-size;
+                vertical-alignment: center;
+                horizontal-alignment: right;
+                width: 12px;
+            }
+        }
+
+        touch := TouchArea {
+            clicked => {
+                popup.show();
+            }
+        }
+    }
+
+    popup := PopupWindow {
+        x: 0;
+        y: root.height + 2px;
+        width: root.width;
+        // Any click — on a row or outside — dismisses the list.
+        close-policy: close-on-click;
+
+        Rectangle {
+            background: root.background-color;
+            border-radius: 4px;
+            border-width: 1px;
+            border-color: root.border-color;
+
+            VerticalLayout {
+                padding: 2px;
+
+                for item[i] in root.model: Rectangle {
+                    height: 26px;
+                    background: i == root.current-index ? root.selection-color : transparent;
+                    border-radius: 3px;
+
+                    HorizontalLayout {
+                        padding-left: 8px;
+                        padding-right: 8px;
+
+                        Text {
+                            text: item;
+                            color: root.foreground-color;
+                            font-size: root.font-size;
+                            vertical-alignment: center;
+                            horizontal-alignment: left;
+                            overflow: elide;
+                        }
+                    }
+
+                    row-touch := TouchArea {
+                        clicked => {
+                            root.selected(item);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Replaces the single `theme.toml` override with a **`themes/` folder** in the config dir, a **dropdown selector** in Settings → Global, and a **Reload theme** button — plus a theme-styled dropdown used across the settings pane.

## Details

- **Themes folder.** Each `<name>.toml` under `<config>/themes/` is a selectable theme. Packaged builds seed the shipped themes **add-missing-only**: new builtins from an update appear, but a file you've edited is never overwritten.
- **Selection setting.** New `[global].theme` holds the chosen file stem, or `"default"` for the in-Rust builtin. Omitted from disk when default; a missing/malformed file falls back to the builtin so a stale name never blocks startup.
- **Live apply.** The active theme is now `Arc<RwLock<Theme>>` shared with the OS-appearance watcher. Picking a theme persists + repaints immediately; **Reload theme** re-reads the selected file from disk and re-applies (for on-disk edits) without a restart. The dropdown list re-scans every time Settings opens.
- **Styled dropdown.** New `ui/themed_combobox.slint` (`PopupWindow`-based) takes the launcher's theme tokens and replaces the std-widgets `ComboBox` for **all three** selectors (theme, theme-mode, alt-action), so they match the palette instead of the backend default style.
- Dropped the old `theme.toml` read path; updated `README.md`, `docs/theming.md`, `docs/platform.md`, and stale code/Slint comments.

## Notes

- Seeding runs from packaged resources only, so unbundled/`cargo install` builds start with just `default` until themes are added to the folder.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets` (clean), `cargo test` (all pass, incl. new settings/theme/seeding tests), and a smoke-launch confirming the daemon boots and applies a theme through the new lock path without panicking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)