### PR TITLE
Render plugin update progress in a dedicated view

### DIFF
--- a/src/app/callbacks.rs
+++ b/src/app/callbacks.rs
@@ -23,6 +23,7 @@ use crate::ui::{ResultRow, ViewBlock};
 use crate::views::{PushError, ViewFrame, ViewStack};
 use crate::window;
 
+use super::host_view::{self as host_view_mod, HostView};
 use super::{ConfirmState, HostMessage};
 
 /// Aggregate of plugin-result + confirm + history state threaded into
@@ -36,6 +37,7 @@ pub(super) struct WindowCallbackCtx {
     pub history_db: Option<QueryHistoryDb>,
     pub history_state: Arc<Mutex<QueryHistoryState>>,
     pub view_stack: Arc<Mutex<ViewStack>>,
+    pub host_view: HostView,
 }
 
 // Window callback wiring is a flat sequence of per-callback blocks;
@@ -56,6 +58,7 @@ pub(super) fn wire_window_callbacks(
         history_db,
         history_state,
         view_stack,
+        host_view,
     } = ctx;
 
     let latest_id_for_main = Arc::clone(latest_id);
@@ -90,6 +93,7 @@ pub(super) fn wire_window_callbacks(
     let history_state_for_invoke = Arc::clone(&history_state);
     let settings_for_invoke = settings.clone();
     let view_stack_for_invoke = Arc::clone(&view_stack);
+    let host_view_for_invoke = Arc::clone(&host_view);
 
     window.on_invoke_selected(move |meta, control, shift, alt| {
         let mods = (u8::from(meta) * crate::hotkey::MOD_META)
@@ -107,6 +111,7 @@ pub(super) fn wire_window_callbacks(
             history_db_for_invoke.as_ref(),
             &history_state_for_invoke,
             &view_stack_for_invoke,
+            &host_view_for_invoke,
             alt_held,
         );
     });
@@ -117,12 +122,15 @@ pub(super) fn wire_window_callbacks(
     // hiding the launcher. The frame's close_signal fires (so the
     // plugin's JS unmounted runs); when the last frame leaves the
     // stack pop_view_frame switches the window back to VIEW-QUERY.
+    // A live host view (e.g. update progress) takes precedence and
+    // closes before the JS stack is touched.
     let weak_for_pop = window.as_weak();
     let view_stack_for_pop = Arc::clone(&view_stack);
+    let host_view_for_pop = Arc::clone(&host_view);
     let tx_for_pop = tx.clone();
 
     window.on_pop_view(move || {
-        pop_view_frame(&view_stack_for_pop, &tx_for_pop, &weak_for_pop);
+        pop_view_frame(&host_view_for_pop, &view_stack_for_pop, &tx_for_pop, &weak_for_pop);
     });
 
     // Fires just before the launcher hides for any reason (Esc on
@@ -130,11 +138,17 @@ pub(super) fn wire_window_callbacks(
     // stack so every per-view spawn_view task gets its unmounted
     // hook called before its QuickJS context is torn down.
     let view_stack_for_clear = Arc::clone(&view_stack);
+    let host_view_for_clear = Arc::clone(&host_view);
     let tx_for_clear = tx.clone();
     let weak_for_clear = window.as_weak();
 
     window.on_clear_view_stack(move || {
-        clear_view_stack_for_hide(&view_stack_for_clear, &tx_for_clear, &weak_for_clear);
+        clear_view_stack_for_hide(
+            &host_view_for_clear,
+            &view_stack_for_clear,
+            &tx_for_clear,
+            &weak_for_clear,
+        );
     });
 
     // Block-level events from inside a pushed view (button click,
@@ -179,18 +193,30 @@ pub(super) fn wire_window_callbacks(
 
     // Install — confirmed.
     let confirm_state_install = Arc::clone(&confirm_state);
+    let host_view_for_confirm_install = Arc::clone(&host_view);
     let weak_confirm_install = window.as_weak();
 
     window.on_confirm_install(move || {
-        send_confirm_decision(&confirm_state_install, true, &weak_confirm_install);
+        send_confirm_decision(
+            &confirm_state_install,
+            &host_view_for_confirm_install,
+            true,
+            &weak_confirm_install,
+        );
     });
 
     // Install — cancelled.
     let confirm_state_cancel = confirm_state;
+    let host_view_for_confirm_cancel = Arc::clone(&host_view);
     let weak_confirm_cancel = window.as_weak();
 
     window.on_confirm_cancel(move || {
-        send_confirm_decision(&confirm_state_cancel, false, &weak_confirm_cancel);
+        send_confirm_decision(
+            &confirm_state_cancel,
+            &host_view_for_confirm_cancel,
+            false,
+            &weak_confirm_cancel,
+        );
     });
 }
 
@@ -276,8 +302,9 @@ fn apply_history_text(window: &QueryWindow, text: &str) {
 }
 
 /// Pull the pending oneshot sender out of `confirm_state` and send `decision`.
-/// Then restore the launcher view so the UI isn't left on the confirm screen.
-fn send_confirm_decision(state: &ConfirmState, decision: bool, weak: &slint::Weak<QueryWindow>) {
+/// Then restore the originating view (launcher by default, host view when
+/// one is live — e.g. during the `update` flow's per-plugin cap prompts).
+fn send_confirm_decision(state: &ConfirmState, host_view: &HostView, decision: bool, weak: &slint::Weak<QueryWindow>) {
     let maybe_tx = match state.lock() {
         Ok(mut guard) => guard.take().map(|p| p.tx),
         Err(err) => {
@@ -290,9 +317,13 @@ fn send_confirm_decision(state: &ConfirmState, decision: bool, weak: &slint::Wea
         tx.send(decision)
             .log_debug("confirm: pending receiver gone before decision");
     }
+    let host_view_active = host_view.lock().is_ok_and(|g| g.is_some());
+    let host_view = Arc::clone(host_view);
     let weak = weak.clone();
     slint::invoke_from_event_loop(move || {
-        if let Some(w) = weak.upgrade() {
+        if host_view_active {
+            host_view_mod::paint(&host_view, &weak);
+        } else if let Some(w) = weak.upgrade() {
             w.invoke_show_query();
         }
     })
@@ -311,6 +342,7 @@ fn invoke_selected(
     history_db: Option<&QueryHistoryDb>,
     history_state: &Arc<Mutex<QueryHistoryState>>,
     view_stack: &Arc<Mutex<ViewStack>>,
+    host_view: &HostView,
     alt_held: bool,
 ) {
     let Some(w) = weak.upgrade() else { return };
@@ -390,7 +422,10 @@ fn invoke_selected(
                     push_view_frame(view_stack, host_tx, &plugin_name, handle, props, reset);
                 }
                 actions::ActionOutcome::CloseView => {
-                    pop_view_frame(view_stack, host_tx, weak);
+                    pop_view_frame(host_view, view_stack, host_tx, weak);
+                }
+                actions::ActionOutcome::ShowUpdateView => {
+                    open_update_view(host_view, host_tx, &w);
                 }
             }
         }
@@ -401,15 +436,47 @@ fn invoke_selected(
     }
 }
 
+/// Seed the host view slot with a fresh [`UpdateViewState`], paint the
+/// initial "Checking…" frame, and post `HostMessage::UpdateAll` so the
+/// runtime thread starts walking plugins. Replaces any existing host
+/// view (firing its cancel token first) so two rapid Enters don't
+/// stack updates.
+fn open_update_view(host_view: &HostView, host_tx: &mpsc::UnboundedSender<HostMessage>, window: &QueryWindow) {
+    {
+        let Ok(mut guard) = host_view.lock() else {
+            tracing::error!("update: host_view lock poisoned on open");
+            return;
+        };
+        if let Some(prev) = guard.take() {
+            prev.cancel_token().cancel();
+        }
+        *guard = Some(host_view_mod::HostViewState::Update(
+            host_view_mod::UpdateViewState::new(),
+        ));
+    }
+    // Initial paint so the user sees the view immediately even before the
+    // runtime thread fetches the plugin list.
+    let weak = window.as_weak();
+    host_view_mod::paint(host_view, &weak);
+
+    if host_tx.send(HostMessage::UpdateAll).is_err() {
+        tracing::error!("update: runtime thread exited; UpdateAll dropped");
+    }
+}
+
 /// Drain every frame off the view stack, sending
 /// [`HostMessage::ViewClose`] for each so the per-view `spawn_view`
 /// tasks run `unmounted` + tear down their JS state. Switches the
-/// window back to `VIEW-QUERY` once the stack is empty. Idempotent.
+/// window back to `VIEW-QUERY` once the stack is empty. Also clears
+/// any live host view (firing its cancel token). Idempotent.
 fn clear_view_stack_for_hide(
+    host_view: &HostView,
     view_stack: &Arc<Mutex<ViewStack>>,
     host_tx: &mpsc::UnboundedSender<HostMessage>,
     weak: &slint::Weak<QueryWindow>,
 ) {
+    let host_view_was_live = take_host_view(host_view);
+
     let popped: Vec<ViewFrame> = {
         let Ok(mut stack) = view_stack.lock() else {
             tracing::error!("views: stack lock poisoned; clear dropped");
@@ -418,7 +485,7 @@ fn clear_view_stack_for_hide(
         stack.clear()
     };
 
-    if popped.is_empty() {
+    if popped.is_empty() && !host_view_was_live {
         return;
     }
     for frame in &popped {
@@ -432,11 +499,31 @@ fn clear_view_stack_for_hide(
             tracing::error!("views: runtime thread exited; view close dropped during clear");
         }
     }
-    tracing::info!(count = popped.len(), "views: stack drained on launcher hide",);
+    tracing::info!(
+        count = popped.len(),
+        host_view_was_live,
+        "views: stack drained on launcher hide",
+    );
 
     if let Some(window) = weak.upgrade() {
         sync_view_blocks_model(&window, Vec::new());
         window.invoke_show_query();
+    }
+}
+
+/// Take the host view slot's contents, firing its cancel token. Returns
+/// `true` when a view was actually live, so callers know whether to
+/// switch the window back to VIEW-QUERY.
+fn take_host_view(host_view: &HostView) -> bool {
+    let Ok(mut guard) = host_view.lock() else {
+        tracing::error!("host_view: lock poisoned; take skipped");
+        return false;
+    };
+    if let Some(state) = guard.take() {
+        state.cancel_token().cancel();
+        true
+    } else {
+        false
     }
 }
 
@@ -847,12 +934,15 @@ fn handle_view_dispatch(
             push_view_frame(view_stack, host_tx, plugin, handle, props, reset);
         }
         actions::ActionOutcome::CloseView => {
-            pop_view_frame(view_stack, host_tx, weak);
+            // A JS view dispatching closeView can only target itself —
+            // host views aren't reachable from JS, so skip the host-view
+            // precedence check the Esc-keypath does.
+            pop_js_view_frame(view_stack, host_tx, weak);
         }
         actions::ActionOutcome::OpenSettingsView => {
             tracing::warn!(%plugin, "views: dispatch of openSettings ignored — would tear down the view");
         }
-        actions::ActionOutcome::HostTask(_) => {
+        actions::ActionOutcome::HostTask(_) | actions::ActionOutcome::ShowUpdateView => {
             tracing::warn!(%plugin, "views: dispatch of host task ignored");
         }
     }
@@ -978,7 +1068,31 @@ fn push_view_frame(
 /// back to the launcher view. A no-op on an empty stack (and not an
 /// error — a stale `closeView` after the user already Esc'd out is a
 /// benign race).
+///
+/// A live host view takes precedence: closing it fires its cancel token
+/// (aborting whatever Rust task drives it) and routes back to the
+/// launcher without touching the JS stack.
 fn pop_view_frame(
+    host_view: &HostView,
+    view_stack: &Arc<Mutex<ViewStack>>,
+    host_tx: &mpsc::UnboundedSender<HostMessage>,
+    weak: &slint::Weak<QueryWindow>,
+) {
+    if take_host_view(host_view) {
+        if let Some(window) = weak.upgrade() {
+            sync_view_blocks_model(&window, Vec::new());
+            window.invoke_show_query();
+        }
+        return;
+    }
+    pop_js_view_frame(view_stack, host_tx, weak);
+}
+
+/// JS-stack pop only — host views are out of scope. Used by
+/// `handle_view_dispatch` since a JS view can't legitimately close a
+/// host view, and by the host-aware [`pop_view_frame`] after it has
+/// verified there's no host view to take.
+fn pop_js_view_frame(
     view_stack: &Arc<Mutex<ViewStack>>,
     host_tx: &mpsc::UnboundedSender<HostMessage>,
     weak: &slint::Weak<QueryWindow>,

--- a/src/app/callbacks.rs
+++ b/src/app/callbacks.rs
@@ -448,11 +448,9 @@ fn open_update_view(host_view: &HostView, host_tx: &mpsc::UnboundedSender<HostMe
             return;
         };
         if let Some(prev) = guard.take() {
-            prev.cancel_token().cancel();
+            prev.cancel.cancel();
         }
-        *guard = Some(host_view_mod::HostViewState::Update(
-            host_view_mod::UpdateViewState::new(),
-        ));
+        *guard = Some(host_view_mod::UpdateViewState::new());
     }
     // Initial paint so the user sees the view immediately even before the
     // runtime thread fetches the plugin list.
@@ -520,7 +518,7 @@ fn take_host_view(host_view: &HostView) -> bool {
         return false;
     };
     if let Some(state) = guard.take() {
-        state.cancel_token().cancel();
+        state.cancel.cancel();
         true
     } else {
         false
@@ -742,7 +740,7 @@ fn paint_view_tree(plugin: &str, handle: u64, tree_json: &str, weak: &slint::Wea
 /// instances survive across re-renders. Replacing the whole
 /// `ModelRc` (the previous behaviour) rebuilt every child, which
 /// stole focus from an Input mid-typing on every keystroke.
-fn sync_view_blocks_model(window: &QueryWindow, blocks: Vec<ViewBlock>) {
+pub(super) fn sync_view_blocks_model(window: &QueryWindow, blocks: Vec<ViewBlock>) {
     // One persistent model per Slint thread (which is also the only
     // thread that calls this).
     thread_local! {

--- a/src/app/callbacks.rs
+++ b/src/app/callbacks.rs
@@ -473,7 +473,7 @@ fn clear_view_stack_for_hide(
     host_tx: &mpsc::UnboundedSender<HostMessage>,
     weak: &slint::Weak<QueryWindow>,
 ) {
-    let host_view_was_live = take_host_view(host_view);
+    let host_view_was_live = host_view_mod::take_and_cancel(host_view);
 
     let popped: Vec<ViewFrame> = {
         let Ok(mut stack) = view_stack.lock() else {
@@ -506,22 +506,6 @@ fn clear_view_stack_for_hide(
     if let Some(window) = weak.upgrade() {
         sync_view_blocks_model(&window, Vec::new());
         window.invoke_show_query();
-    }
-}
-
-/// Take the host view slot's contents, firing its cancel token. Returns
-/// `true` when a view was actually live, so callers know whether to
-/// switch the window back to VIEW-QUERY.
-fn take_host_view(host_view: &HostView) -> bool {
-    let Ok(mut guard) = host_view.lock() else {
-        tracing::error!("host_view: lock poisoned; take skipped");
-        return false;
-    };
-    if let Some(state) = guard.take() {
-        state.cancel.cancel();
-        true
-    } else {
-        false
     }
 }
 
@@ -1076,7 +1060,7 @@ fn pop_view_frame(
     host_tx: &mpsc::UnboundedSender<HostMessage>,
     weak: &slint::Weak<QueryWindow>,
 ) {
-    if take_host_view(host_view) {
+    if host_view_mod::take_and_cancel(host_view) {
         if let Some(window) = weak.upgrade() {
             sync_view_blocks_model(&window, Vec::new());
             window.invoke_show_query();

--- a/src/app/host_view.rs
+++ b/src/app/host_view.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, Mutex};
 
 use tokio_util::sync::CancellationToken;
 
+use super::callbacks::sync_view_blocks_model;
 use crate::QueryWindow;
 use crate::logging::LogErr;
 use crate::ui::ViewBlock;
@@ -49,6 +50,21 @@ impl UpdateViewState {
     pub(super) fn position(&self, name: &str) -> Option<usize> {
         self.entries.iter().position(|e| e.name == name)
     }
+}
+
+/// Clear the slot, firing the captured cancel token. Returns `true` when
+/// a view was actually live so callers can branch on "was anything
+/// closed?" without re-locking. Lock-poisoning and an already-empty slot
+/// both report `false`.
+pub(super) fn take_and_cancel(slot: &HostView) -> bool {
+    let Ok(mut guard) = slot.lock() else {
+        tracing::error!("host_view: lock poisoned; take skipped");
+        return false;
+    };
+    let Some(state) = guard.take() else { return false };
+
+    state.cancel.cancel();
+    true
 }
 
 /// One plugin's row in the update view.
@@ -143,8 +159,9 @@ fn paint_update(window: &QueryWindow, state: &UpdateViewState) {
         -1.0
     } else {
         #[allow(clippy::cast_precision_loss)]
-        let v = done as f64 / total as f64;
-        v
+        {
+            done as f64 / total as f64
+        }
     };
     blocks.push(progress_block(progress_value));
 
@@ -158,19 +175,17 @@ fn paint_update(window: &QueryWindow, state: &UpdateViewState) {
     }
 
     if let Some(summary) = state.summary.as_ref() {
-        let mut parts = Vec::new();
-        if summary.updated > 0 {
-            parts.push(format!("{} updated", summary.updated));
-        }
-        if summary.up_to_date > 0 {
-            parts.push(format!("{} up to date", summary.up_to_date));
-        }
-        if summary.skipped > 0 {
-            parts.push(format!("{} skipped", summary.skipped));
-        }
-        if summary.failed > 0 {
-            parts.push(format!("{} failed", summary.failed));
-        }
+        let parts: Vec<String> = [
+            (summary.updated, "updated"),
+            (summary.up_to_date, "up to date"),
+            (summary.skipped, "skipped"),
+            (summary.failed, "failed"),
+        ]
+        .into_iter()
+        .filter(|(n, _)| *n > 0)
+        .map(|(n, label)| format!("{n} {label}"))
+        .collect();
+
         let line = if parts.is_empty() {
             "Nothing to update".to_owned()
         } else {
@@ -185,7 +200,7 @@ fn paint_update(window: &QueryWindow, state: &UpdateViewState) {
     // Reuse the same persistent VecModel JS view paints use — keeps the
     // Slint child elements alive across status mutations instead of
     // rebuilding every block on every paint.
-    super::callbacks::sync_view_blocks_model(window, blocks);
+    sync_view_blocks_model(window, blocks);
     window.invoke_show_view_frame();
 }
 

--- a/src/app/host_view.rs
+++ b/src/app/host_view.rs
@@ -1,0 +1,352 @@
+//! Host-driven view-frame painting.
+//!
+//! The view-frame system in `src/sdk/view.rs` is plumbed for JS plugins:
+//! `setup → render → mounted` runs inside a `QuickJS` context and the
+//! rendered tree arrives at the host through a `RuntimeBridge` callback.
+//! Some flows — currently the Core built-in's `update` verb — need the
+//! same Slint surface but originate in Rust, where there's no plugin
+//! context to drive a render loop. This module owns those flows.
+//!
+//! Shape: `HostView` holds a single optional state value. While `Some`,
+//! the host view is "live" — it owns `current-view = VIEW-VIEWS` and any
+//! Esc / hide event closes it (firing its `cancel` token so the Rust task
+//! producing updates bails) instead of falling through to the JS plugin
+//! view stack.
+//!
+//! Today the only flavour is [`UpdateViewState`] (multi-plugin update
+//! progress). The enum-of-state shape leaves room for future host-driven
+//! views without re-plumbing the slot.
+
+use std::sync::{Arc, Mutex};
+
+use slint::{ModelRc, VecModel};
+use tokio_util::sync::CancellationToken;
+
+use crate::QueryWindow;
+use crate::logging::LogErr;
+use crate::ui::ViewBlock;
+
+/// Shared slot. `None` when no host view is live.
+pub(super) type HostView = Arc<Mutex<Option<HostViewState>>>;
+
+/// Build a fresh empty slot for `AppState::start`.
+pub(super) fn new_slot() -> HostView {
+    Arc::new(Mutex::new(None))
+}
+
+/// Variants of host-driven view. Only one is live at a time — the
+/// `HostView` slot stores `Option<HostViewState>`.
+pub(super) enum HostViewState {
+    Update(UpdateViewState),
+}
+
+impl HostViewState {
+    /// Cancellation token to fire when the view closes. Propagates to the
+    /// Rust task producing state mutations so it can bail early.
+    pub(super) fn cancel_token(&self) -> CancellationToken {
+        match self {
+            HostViewState::Update(s) => s.cancel.clone(),
+        }
+    }
+}
+
+/// Per-plugin update progress, painted as a single view-frame.
+pub(super) struct UpdateViewState {
+    pub entries: Vec<UpdateEntry>,
+    pub summary: Option<UpdateSummary>,
+    pub cancel: CancellationToken,
+}
+
+impl UpdateViewState {
+    pub(super) fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            summary: None,
+            cancel: CancellationToken::new(),
+        }
+    }
+
+    /// Index of the entry matching `name`, or `None` if absent.
+    pub(super) fn position(&self, name: &str) -> Option<usize> {
+        self.entries.iter().position(|e| e.name == name)
+    }
+}
+
+/// One plugin's row in the update view.
+pub(super) struct UpdateEntry {
+    pub name: String,
+    pub local_version: String,
+    pub status: EntryStatus,
+}
+
+#[derive(Clone)]
+pub(super) enum EntryStatus {
+    /// Discovered but not yet checked.
+    Queued,
+    /// Hitting `manifestUrl`.
+    Checking,
+    /// Local == remote (or remote isn't newer).
+    UpToDate,
+    /// Local plugin has no `manifestUrl`, can't auto-update.
+    Skipped { reason: String },
+    /// Download + extract in flight.
+    Updating { new_version: String },
+    /// Install finished.
+    Updated { new_version: String },
+    /// Check or install failed.
+    Failed { error: String },
+}
+
+/// End-of-run tallies.
+pub(super) struct UpdateSummary {
+    pub updated: usize,
+    pub up_to_date: usize,
+    pub skipped: usize,
+    pub failed: usize,
+}
+
+/// Paint the host view's current state to the window. Called on the Slint
+/// thread. No-op when the slot is empty (`take()` already cleared it for
+/// a pending close), which keeps a stray repaint after Esc benign.
+pub(super) fn paint(slot: &HostView, weak: &slint::Weak<QueryWindow>) {
+    let Some(window) = weak.upgrade() else { return };
+    let Ok(guard) = slot.lock() else {
+        tracing::error!("host_view: slot lock poisoned; paint skipped");
+        return;
+    };
+    let Some(state) = guard.as_ref() else { return };
+
+    match state {
+        HostViewState::Update(s) => paint_update(&window, s),
+    }
+}
+
+/// Schedule a `paint` on the Slint event loop. Safe to call from the
+/// runtime thread.
+pub(super) fn schedule_paint(slot: &HostView, weak: &slint::Weak<QueryWindow>) {
+    let slot = Arc::clone(slot);
+    let weak = weak.clone();
+    slint::invoke_from_event_loop(move || {
+        paint(&slot, &weak);
+    })
+    .log_debug("host_view: schedule_paint invoke_from_event_loop");
+}
+
+fn paint_update(window: &QueryWindow, state: &UpdateViewState) {
+    let total = state.entries.len();
+    let done = state
+        .entries
+        .iter()
+        .filter(|e| {
+            matches!(
+                e.status,
+                EntryStatus::UpToDate
+                    | EntryStatus::Updated { .. }
+                    | EntryStatus::Skipped { .. }
+                    | EntryStatus::Failed { .. }
+            )
+        })
+        .count();
+
+    let mut blocks = Vec::with_capacity(2 + state.entries.len() * 2 + 1);
+
+    let heading_text = if state.summary.is_some() {
+        "Update complete".to_owned()
+    } else if total == 0 {
+        "Checking for plugins…".to_owned()
+    } else {
+        format!("Updating plugins — {done} of {total}")
+    };
+
+    blocks.push(text_block("heading", &heading_text, "", ""));
+
+    let progress_value = if state.summary.is_some() {
+        1.0
+    } else if total == 0 {
+        -1.0
+    } else {
+        #[allow(clippy::cast_precision_loss)]
+        let v = done as f64 / total as f64;
+        v
+    };
+    blocks.push(progress_block(progress_value));
+
+    for entry in &state.entries {
+        let (line, tone) = format_entry(entry);
+        blocks.push(text_block("text", &line, tone, ""));
+
+        if matches!(entry.status, EntryStatus::Updating { .. } | EntryStatus::Checking) {
+            blocks.push(spinner_block(""));
+        }
+    }
+
+    if let Some(summary) = state.summary.as_ref() {
+        let mut parts = Vec::new();
+        if summary.updated > 0 {
+            parts.push(format!("{} updated", summary.updated));
+        }
+        if summary.up_to_date > 0 {
+            parts.push(format!("{} up to date", summary.up_to_date));
+        }
+        if summary.skipped > 0 {
+            parts.push(format!("{} skipped", summary.skipped));
+        }
+        if summary.failed > 0 {
+            parts.push(format!("{} failed", summary.failed));
+        }
+        let line = if parts.is_empty() {
+            "Nothing to update".to_owned()
+        } else {
+            parts.join(", ")
+        };
+        let tone = if summary.failed > 0 { "error" } else { "success" };
+        blocks.push(text_block("text", &line, tone, "lg"));
+    }
+
+    window.set_view_frame_title("Update plugins".into());
+    window.set_view_has_title(true);
+    window.set_view_blocks(ModelRc::new(VecModel::from(blocks)));
+    window.invoke_show_view_frame();
+}
+
+fn format_entry(entry: &UpdateEntry) -> (String, &'static str) {
+    let name = &entry.name;
+    let local = if entry.local_version.is_empty() {
+        String::new()
+    } else {
+        format!(" v{}", entry.local_version)
+    };
+
+    match &entry.status {
+        EntryStatus::Queued => (format!("{name}{local} — queued"), "muted"),
+        EntryStatus::Checking => (format!("{name}{local} — checking…"), "muted"),
+        EntryStatus::UpToDate => (format!("{name}{local} — up to date"), "muted"),
+        EntryStatus::Skipped { reason } => (format!("{name}{local} — skipped: {reason}"), "muted"),
+        EntryStatus::Updating { new_version } => (format!("{name}{local} → v{new_version} — updating…"), "warning"),
+        EntryStatus::Updated { new_version } => (format!("{name}{local} → v{new_version} — updated"), "success"),
+        EntryStatus::Failed { error } => (format!("{name}{local} — failed: {error}"), "error"),
+    }
+}
+
+/// Construct a heading/text block. `kind` is "heading" or "text".
+fn text_block(kind: &'static str, text: &str, tone: &str, size: &str) -> ViewBlock {
+    ViewBlock {
+        kind: kind.into(),
+        text: text.into(),
+        has_text: !text.is_empty(),
+        tone: tone.into(),
+        size: size.into(),
+        label: String::new().into(),
+        has_label: false,
+        value: String::new().into(),
+        has_value: false,
+        id: String::new().into(),
+        on_click_id: 0,
+        on_change_id: 0,
+        on_submit_id: 0,
+        has_on_click: false,
+        has_on_change: false,
+        has_on_submit: false,
+        progress_value: -1.0,
+        has_progress_value: false,
+    }
+}
+
+fn spinner_block(label: &str) -> ViewBlock {
+    ViewBlock {
+        kind: "spinner".into(),
+        text: String::new().into(),
+        has_text: false,
+        tone: String::new().into(),
+        size: String::new().into(),
+        label: label.into(),
+        has_label: !label.is_empty(),
+        value: String::new().into(),
+        has_value: false,
+        id: String::new().into(),
+        on_click_id: 0,
+        on_change_id: 0,
+        on_submit_id: 0,
+        has_on_click: false,
+        has_on_change: false,
+        has_on_submit: false,
+        progress_value: -1.0,
+        has_progress_value: false,
+    }
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn progress_block(value: f64) -> ViewBlock {
+    let has_value = value >= 0.0;
+    ViewBlock {
+        kind: "progress".into(),
+        text: String::new().into(),
+        has_text: false,
+        tone: String::new().into(),
+        size: String::new().into(),
+        label: String::new().into(),
+        has_label: false,
+        value: String::new().into(),
+        has_value: false,
+        id: String::new().into(),
+        on_click_id: 0,
+        on_change_id: 0,
+        on_submit_id: 0,
+        has_on_click: false,
+        has_on_change: false,
+        has_on_submit: false,
+        progress_value: if has_value { value.clamp(0.0, 1.0) as f32 } else { -1.0 },
+        has_progress_value: has_value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(name: &str, status: EntryStatus) -> UpdateEntry {
+        UpdateEntry {
+            name: name.into(),
+            local_version: "1.0.0".into(),
+            status,
+        }
+    }
+
+    #[test]
+    fn format_entry_uses_warning_tone_during_update() {
+        let (_, tone) = format_entry(&entry(
+            "foo",
+            EntryStatus::Updating {
+                new_version: "1.1.0".into(),
+            },
+        ));
+        assert_eq!(tone, "warning");
+    }
+
+    #[test]
+    fn format_entry_uses_error_tone_on_failure() {
+        let (line, tone) = format_entry(&entry("foo", EntryStatus::Failed { error: "boom".into() }));
+        assert_eq!(tone, "error");
+        assert!(line.contains("boom"));
+    }
+
+    #[test]
+    fn format_entry_uses_success_tone_after_update() {
+        let (_, tone) = format_entry(&entry(
+            "foo",
+            EntryStatus::Updated {
+                new_version: "1.1.0".into(),
+            },
+        ));
+        assert_eq!(tone, "success");
+    }
+
+    #[test]
+    fn position_returns_index_of_matching_entry() {
+        let mut state = UpdateViewState::new();
+        state.entries.push(entry("a", EntryStatus::Queued));
+        state.entries.push(entry("b", EntryStatus::Queued));
+        assert_eq!(state.position("b"), Some(1));
+        assert_eq!(state.position("c"), None);
+    }
+}

--- a/src/app/host_view.rs
+++ b/src/app/host_view.rs
@@ -7,19 +7,14 @@
 //! same Slint surface but originate in Rust, where there's no plugin
 //! context to drive a render loop. This module owns those flows.
 //!
-//! Shape: `HostView` holds a single optional state value. While `Some`,
+//! Shape: [`HostView`] holds a single optional state value. While `Some`,
 //! the host view is "live" — it owns `current-view = VIEW-VIEWS` and any
 //! Esc / hide event closes it (firing its `cancel` token so the Rust task
 //! producing updates bails) instead of falling through to the JS plugin
 //! view stack.
-//!
-//! Today the only flavour is [`UpdateViewState`] (multi-plugin update
-//! progress). The enum-of-state shape leaves room for future host-driven
-//! views without re-plumbing the slot.
 
 use std::sync::{Arc, Mutex};
 
-use slint::{ModelRc, VecModel};
 use tokio_util::sync::CancellationToken;
 
 use crate::QueryWindow;
@@ -27,27 +22,11 @@ use crate::logging::LogErr;
 use crate::ui::ViewBlock;
 
 /// Shared slot. `None` when no host view is live.
-pub(super) type HostView = Arc<Mutex<Option<HostViewState>>>;
+pub(super) type HostView = Arc<Mutex<Option<UpdateViewState>>>;
 
 /// Build a fresh empty slot for `AppState::start`.
 pub(super) fn new_slot() -> HostView {
     Arc::new(Mutex::new(None))
-}
-
-/// Variants of host-driven view. Only one is live at a time — the
-/// `HostView` slot stores `Option<HostViewState>`.
-pub(super) enum HostViewState {
-    Update(UpdateViewState),
-}
-
-impl HostViewState {
-    /// Cancellation token to fire when the view closes. Propagates to the
-    /// Rust task producing state mutations so it can bail early.
-    pub(super) fn cancel_token(&self) -> CancellationToken {
-        match self {
-            HostViewState::Update(s) => s.cancel.clone(),
-        }
-    }
 }
 
 /// Per-plugin update progress, painted as a single view-frame.
@@ -116,9 +95,7 @@ pub(super) fn paint(slot: &HostView, weak: &slint::Weak<QueryWindow>) {
     };
     let Some(state) = guard.as_ref() else { return };
 
-    match state {
-        HostViewState::Update(s) => paint_update(&window, s),
-    }
+    paint_update(&window, state);
 }
 
 /// Schedule a `paint` on the Slint event loop. Safe to call from the
@@ -205,7 +182,10 @@ fn paint_update(window: &QueryWindow, state: &UpdateViewState) {
 
     window.set_view_frame_title("Update plugins".into());
     window.set_view_has_title(true);
-    window.set_view_blocks(ModelRc::new(VecModel::from(blocks)));
+    // Reuse the same persistent VecModel JS view paints use — keeps the
+    // Slint child elements alive across status mutations instead of
+    // rebuilding every block on every paint.
+    super::callbacks::sync_view_blocks_model(window, blocks);
     window.invoke_show_view_frame();
 }
 
@@ -236,42 +216,18 @@ fn text_block(kind: &'static str, text: &str, tone: &str, size: &str) -> ViewBlo
         has_text: !text.is_empty(),
         tone: tone.into(),
         size: size.into(),
-        label: String::new().into(),
-        has_label: false,
-        value: String::new().into(),
-        has_value: false,
-        id: String::new().into(),
-        on_click_id: 0,
-        on_change_id: 0,
-        on_submit_id: 0,
-        has_on_click: false,
-        has_on_change: false,
-        has_on_submit: false,
         progress_value: -1.0,
-        has_progress_value: false,
+        ..ViewBlock::default()
     }
 }
 
 fn spinner_block(label: &str) -> ViewBlock {
     ViewBlock {
         kind: "spinner".into(),
-        text: String::new().into(),
-        has_text: false,
-        tone: String::new().into(),
-        size: String::new().into(),
         label: label.into(),
         has_label: !label.is_empty(),
-        value: String::new().into(),
-        has_value: false,
-        id: String::new().into(),
-        on_click_id: 0,
-        on_change_id: 0,
-        on_submit_id: 0,
-        has_on_click: false,
-        has_on_change: false,
-        has_on_submit: false,
         progress_value: -1.0,
-        has_progress_value: false,
+        ..ViewBlock::default()
     }
 }
 
@@ -280,23 +236,9 @@ fn progress_block(value: f64) -> ViewBlock {
     let has_value = value >= 0.0;
     ViewBlock {
         kind: "progress".into(),
-        text: String::new().into(),
-        has_text: false,
-        tone: String::new().into(),
-        size: String::new().into(),
-        label: String::new().into(),
-        has_label: false,
-        value: String::new().into(),
-        has_value: false,
-        id: String::new().into(),
-        on_click_id: 0,
-        on_change_id: 0,
-        on_submit_id: 0,
-        has_on_click: false,
-        has_on_change: false,
-        has_on_submit: false,
         progress_value: if has_value { value.clamp(0.0, 1.0) as f32 } else { -1.0 },
         has_progress_value: has_value,
+        ..ViewBlock::default()
     }
 }
 

--- a/src/app/install_flow.rs
+++ b/src/app/install_flow.rs
@@ -637,22 +637,22 @@ fn seed_update_entries(
     weak: &slint::Weak<QueryWindow>,
     plugins: &[Arc<crate::plugins::runtime::LoadedPlugin>],
 ) {
-    update_view_state(host_view, weak, |s| {
-        for p in plugins {
-            let status = if p.manifest.manifest_url.is_none() {
+    let entries: Vec<UpdateEntry> = plugins
+        .iter()
+        .map(|p| UpdateEntry {
+            name: p.manifest.name.clone(),
+            local_version: p.manifest.version.clone().unwrap_or_default(),
+            status: if p.manifest.manifest_url.is_none() {
                 EntryStatus::Skipped {
                     reason: "no manifestUrl".to_owned(),
                 }
             } else {
                 EntryStatus::Queued
-            };
-            s.entries.push(UpdateEntry {
-                name: p.manifest.name.clone(),
-                local_version: p.manifest.version.clone().unwrap_or_default(),
-                status,
-            });
-        }
-    });
+            },
+        })
+        .collect();
+
+    update_view_state(host_view, weak, |s| s.entries = entries);
 }
 
 /// Run one plugin's update sub-flow: fetch manifest, version-compare,
@@ -772,11 +772,11 @@ where
 /// per-plugin loop, but bail safely rather than corrupting state).
 fn set_entry_status(host_view: &HostView, weak: &slint::Weak<QueryWindow>, name: &str, status: EntryStatus) {
     update_view_state(host_view, weak, |s| {
-        if let Some(idx) = s.position(name) {
-            s.entries[idx].status = status;
-        } else {
+        let Some(idx) = s.position(name) else {
             tracing::debug!(%name, "update: entry not found for status update");
-        }
+            return;
+        };
+        s.entries[idx].status = status;
     });
 }
 

--- a/src/app/install_flow.rs
+++ b/src/app/install_flow.rs
@@ -1,11 +1,16 @@
 //! Install / update / reload pipeline driven by Core's `install <url>`,
 //! `update`, and `reload` verbs.
 //!
-//! Each verb fires a single `HostTask` (see [`crate::plugins::actions`]) at
-//! the runtime thread, which calls into [`handle_host_task`]. From there the
-//! pipeline streams progress rows back into the launcher's result list
-//! through [`ProgressEmitter`] under stable per-task keys so re-emitted lines
+//! Install + reload fire a [`actions::HostTask`] at the runtime thread,
+//! which calls into [`handle_host_task`]. From there the pipeline streams
+//! progress rows back into the launcher's result list through
+//! [`ProgressEmitter`] under stable per-task keys so re-emitted lines
 //! replace the previous row in place.
+//!
+//! Update is different: it opens a dedicated host view (see
+//! [`super::host_view`]) and the per-plugin progress lives as state
+//! mutations on that view instead of rows. [`run_update_view`] is the
+//! entry point.
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -27,6 +32,7 @@ use crate::settings_ui::SettingsController;
 use crate::ui::ConfirmCapRow;
 
 use super::ConfirmState;
+use super::host_view::{self, EntryStatus, HostView, HostViewState, UpdateEntry, UpdateSummary};
 
 /// Stable-key stream of progress rows shared with the launcher's result
 /// list. Re-emitting a key replaces the previous row in place, so the
@@ -120,9 +126,6 @@ pub(super) async fn handle_host_task(
         }
         actions::HostTask::Install { url } => {
             run_install(&url, registry, &progress, &confirm_state, &weak, settings).await;
-        }
-        actions::HostTask::UpdateAll => {
-            run_update_all(registry, &progress, &confirm_state, &weak, settings).await;
         }
     }
 }
@@ -543,99 +546,236 @@ fn emit_install_failure(progress: &ProgressEmitter, progress_key: &str, plugin_n
     );
 }
 
-async fn run_update_all(
+/// Update entry point — runs against a host-driven update view (see
+/// [`super::host_view`]). The Slint thread already seeded the slot before
+/// posting `HostMessage::UpdateAll`; here we discover the plugin list,
+/// fill in entries, then walk each one updating the view state in place.
+/// Cancellation: the slot's cancel token fires on Esc — we abort between
+/// plugins (and skip pending ones with `is_cancelled()` checks).
+pub(super) async fn run_update_view(
     registry: &PluginRegistry,
-    progress: &ProgressEmitter,
-    confirm_state: &ConfirmState,
-    weak: &slint::Weak<QueryWindow>,
+    host_view: HostView,
+    weak: slint::Weak<QueryWindow>,
+    confirm_state: ConfirmState,
     settings: &SettingsController,
 ) {
     let plugins = registry.snapshot().await;
+    let cancel = match host_view.lock() {
+        Ok(g) => g.as_ref().map(host_view::HostViewState::cancel_token),
+        Err(err) => {
+            tracing::error!(%err, "update: host_view lock poisoned at start");
+            return;
+        }
+    };
+    let Some(cancel) = cancel else {
+        tracing::warn!("update: host view slot empty at start; aborting");
+        return;
+    };
 
-    if plugins.is_empty() {
-        progress.emit(
-            "update-summary",
-            "No plugins loaded".to_owned(),
-            Some("nothing to update".to_owned()),
-        );
+    seed_update_entries(&host_view, &weak, &plugins);
+
+    let mut tally = UpdateTally::default();
+
+    for plugin in plugins {
+        if cancel.is_cancelled() {
+            tracing::info!("update: cancelled mid-loop");
+            return;
+        }
+        process_one_update(
+            &plugin,
+            &host_view,
+            &weak,
+            registry,
+            &confirm_state,
+            settings,
+            &mut tally,
+        )
+        .await;
+        // The install pipeline switches the window to VIEW-CONFIRM mid-flow
+        // for capability prompts. After the prompt resolves, the confirm
+        // callback returns the window to VIEW-QUERY by default — repaint
+        // the host view so we come back to it instead of a blank launcher.
+        host_view::schedule_paint(&host_view, &weak);
+    }
+
+    update_view_state(&host_view, &weak, |s| {
+        s.summary = Some(UpdateSummary {
+            updated: tally.updated,
+            up_to_date: tally.up_to_date,
+            skipped: tally.skipped,
+            failed: tally.failed,
+        });
+    });
+}
+
+#[derive(Default)]
+struct UpdateTally {
+    updated: usize,
+    up_to_date: usize,
+    skipped: usize,
+    failed: usize,
+}
+
+/// Seed one entry per plugin so the view paints "N queued" immediately.
+/// Plugins without `manifestUrl` get Skipped up front.
+fn seed_update_entries(
+    host_view: &HostView,
+    weak: &slint::Weak<QueryWindow>,
+    plugins: &[Arc<crate::plugins::runtime::LoadedPlugin>],
+) {
+    update_view_state(host_view, weak, |s| {
+        for p in plugins {
+            let status = if p.manifest.manifest_url.is_none() {
+                EntryStatus::Skipped {
+                    reason: "no manifestUrl".to_owned(),
+                }
+            } else {
+                EntryStatus::Queued
+            };
+            s.entries.push(UpdateEntry {
+                name: p.manifest.name.clone(),
+                local_version: p.manifest.version.clone().unwrap_or_default(),
+                status,
+            });
+        }
+    });
+}
+
+/// Run one plugin's update sub-flow: fetch manifest, version-compare,
+/// optionally drive `install_pipeline`. Mutates `tally` and the matching
+/// view entry's status as it goes.
+#[allow(clippy::too_many_arguments)]
+async fn process_one_update(
+    plugin: &Arc<crate::plugins::runtime::LoadedPlugin>,
+    host_view: &HostView,
+    weak: &slint::Weak<QueryWindow>,
+    registry: &PluginRegistry,
+    confirm_state: &ConfirmState,
+    settings: &SettingsController,
+    tally: &mut UpdateTally,
+) {
+    let name = plugin.manifest.name.clone();
+    let local_version = plugin.manifest.version.clone().unwrap_or_default();
+    let installed_caps = plugin.manifest.capabilities.clone();
+
+    let Some(manifest_url) = plugin.manifest.manifest_url.clone() else {
+        tally.skipped += 1;
+        // Entry was already seeded with Skipped — nothing to update.
+        return;
+    };
+
+    set_entry_status(host_view, weak, &name, EntryStatus::Checking);
+
+    let remote = match plugins::install::fetch_and_validate_manifest(&manifest_url).await {
+        Ok(m) => m,
+        Err(err) => {
+            tally.failed += 1;
+            set_entry_status(host_view, weak, &name, EntryStatus::Failed { error: err.to_string() });
+
+            return;
+        }
+    };
+
+    let remote_version = remote.version.clone().unwrap_or_default();
+
+    if !plugins::manifest::is_newer_version(&remote_version, &local_version) {
+        tally.up_to_date += 1;
+        set_entry_status(host_view, weak, &name, EntryStatus::UpToDate);
 
         return;
     }
-    let mut updated = 0usize;
-    let mut up_to_date = 0usize;
-    let mut failed = 0usize;
-
-    for plugin in plugins {
-        let local_version = plugin.manifest.version.clone().unwrap_or_default();
-        let installed_caps = plugin.manifest.capabilities.clone();
-        let Some(manifest_url) = plugin.manifest.manifest_url.clone() else {
-            let key = format!("update-{}", plugin.manifest.name);
-            progress.emit(
-                &key,
-                format!("Skipped {}", plugin.manifest.name),
-                Some("no manifestUrl — plugin opts out of updates".to_owned()),
-            );
-
-            continue;
-        };
-
-        let name = plugin.manifest.name.clone();
-        let key = format!("update-{name}");
-
-        progress.emit(&key, format!("Checking {name}…"), Some(manifest_url.clone()));
-
-        let remote = match plugins::install::fetch_and_validate_manifest(&manifest_url).await {
-            Ok(m) => m,
-            Err(err) => {
-                failed += 1;
-                progress.emit(&key, format!("Update check failed: {name}"), Some(err.to_string()));
-
-                continue;
-            }
-        };
-
-        let remote_version = remote.version.clone().unwrap_or_default();
-
-        if !plugins::manifest::is_newer_version(&remote_version, &local_version) {
-            up_to_date += 1;
-            progress.emit(&key, format!("Up to date: {name} v{local_version}"), None);
-
-            continue;
-        }
-
-        progress.emit(
-            &key,
-            format!("Updating {name} v{local_version} → v{remote_version}…"),
-            None,
-        );
-
-        // Only prompt if the update introduces new capabilities.
-        let needs_prompt = crate::confirm::update_needs_prompt(&remote.capabilities, &installed_caps);
-        let caps_arg: Option<&[String]> = needs_prompt.then_some(&installed_caps);
-
-        if install_pipeline(
-            &manifest_url,
-            &key,
-            caps_arg,
-            registry,
-            progress,
-            confirm_state,
-            weak,
-            settings,
-        )
-        .await
-        .is_some()
-        {
-            updated += 1;
-        } else {
-            failed += 1;
-        }
-    }
-    progress.emit(
-        "update-summary",
-        format!("Update complete — {updated} updated, {up_to_date} up to date, {failed} failed"),
-        None,
+    set_entry_status(
+        host_view,
+        weak,
+        &name,
+        EntryStatus::Updating {
+            new_version: remote_version.clone(),
+        },
     );
+
+    let needs_prompt = crate::confirm::update_needs_prompt(&remote.capabilities, &installed_caps);
+    let caps_arg: Option<&[String]> = needs_prompt.then_some(&installed_caps);
+
+    // install_pipeline writes progress rows through ProgressEmitter; we
+    // wire a silent one here so those writes don't clobber the real
+    // launcher result list (which becomes visible again the moment the
+    // user Escs out of the update view). Setting `query_id = 0` against
+    // a latest_id pre-bumped to 1 makes every emit() short-circuit on
+    // the stale-check at the top of ProgressEmitter::emit.
+    let row_progress = ProgressEmitter::new(
+        0,
+        weak.clone(),
+        Arc::new(Mutex::new(Vec::new())),
+        Arc::new(AtomicU64::new(1)),
+    );
+
+    let result = install_pipeline(
+        &manifest_url,
+        &format!("update-{name}"),
+        caps_arg,
+        registry,
+        &row_progress,
+        confirm_state,
+        weak,
+        settings,
+    )
+    .await;
+
+    if result.is_some() {
+        tally.updated += 1;
+        set_entry_status(
+            host_view,
+            weak,
+            &name,
+            EntryStatus::Updated {
+                new_version: remote_version,
+            },
+        );
+    } else {
+        tally.failed += 1;
+        set_entry_status(
+            host_view,
+            weak,
+            &name,
+            EntryStatus::Failed {
+                error: "install pipeline failed (see logs)".to_owned(),
+            },
+        );
+    }
+}
+
+/// Mutate the live update-view state under the slot lock and trigger a
+/// repaint. No-op when the slot is empty (the user closed the view
+/// mid-run). Runs on the runtime thread; the repaint hops to the Slint
+/// thread.
+fn update_view_state<F>(host_view: &HostView, weak: &slint::Weak<QueryWindow>, mutate: F)
+where
+    F: FnOnce(&mut host_view::UpdateViewState),
+{
+    {
+        let Ok(mut guard) = host_view.lock() else {
+            tracing::error!("update: host_view lock poisoned during update");
+            return;
+        };
+        let Some(HostViewState::Update(state)) = guard.as_mut() else {
+            return;
+        };
+        mutate(state);
+    }
+    host_view::schedule_paint(host_view, weak);
+}
+
+/// Find the entry by name and replace its status. Logs a debug line when
+/// the entry isn't found (would mean a race between seeding and the
+/// per-plugin loop, but bail safely rather than corrupting state).
+fn set_entry_status(host_view: &HostView, weak: &slint::Weak<QueryWindow>, name: &str, status: EntryStatus) {
+    update_view_state(host_view, weak, |s| {
+        if let Some(idx) = s.position(name) {
+            s.entries[idx].status = status;
+        } else {
+            tracing::debug!(%name, "update: entry not found for status update");
+        }
+    });
 }
 
 fn temp_dir_for_install(name: &str) -> std::io::Result<PathBuf> {

--- a/src/app/install_flow.rs
+++ b/src/app/install_flow.rs
@@ -132,8 +132,8 @@ pub(super) async fn handle_host_task(
 
 /// Drive the install pipeline for a single manifest URL, streaming progress
 /// rows under the stable key `install`. Returns the loaded plugin's name on
-/// success — `run_update_all` re-uses this so each per-plugin update lands
-/// progress under a stable per-plugin key.
+/// success. The update flow drives [`install_pipeline`] directly (under a
+/// per-plugin key), so it doesn't route through here.
 async fn run_install(
     url: &str,
     registry: &PluginRegistry,

--- a/src/app/install_flow.rs
+++ b/src/app/install_flow.rs
@@ -32,7 +32,7 @@ use crate::settings_ui::SettingsController;
 use crate::ui::ConfirmCapRow;
 
 use super::ConfirmState;
-use super::host_view::{self, EntryStatus, HostView, HostViewState, UpdateEntry, UpdateSummary};
+use super::host_view::{self, EntryStatus, HostView, UpdateEntry, UpdateSummary};
 
 /// Stable-key stream of progress rows shared with the launcher's result
 /// list. Re-emitting a key replaces the previous row in place, so the
@@ -561,7 +561,7 @@ pub(super) async fn run_update_view(
 ) {
     let plugins = registry.snapshot().await;
     let cancel = match host_view.lock() {
-        Ok(g) => g.as_ref().map(host_view::HostViewState::cancel_token),
+        Ok(g) => g.as_ref().map(|s| s.cancel.clone()),
         Err(err) => {
             tracing::error!(%err, "update: host_view lock poisoned at start");
             return;
@@ -575,6 +575,19 @@ pub(super) async fn run_update_view(
     seed_update_entries(&host_view, &weak, &plugins);
 
     let mut tally = UpdateTally::default();
+    // install_pipeline writes progress rows through ProgressEmitter; we
+    // wire a silent one so those writes don't clobber the real launcher
+    // result list (which becomes visible again the moment the user Escs
+    // out of the update view). `query_id = 0` against a pre-bumped
+    // latest_id of 1 makes every emit() short-circuit on the stale-check
+    // at the top of `ProgressEmitter::emit`. Hoisting it out of the loop
+    // avoids 16+ pointless allocations per update run.
+    let silent_progress = ProgressEmitter::new(
+        0,
+        weak.clone(),
+        Arc::new(Mutex::new(Vec::new())),
+        Arc::new(AtomicU64::new(1)),
+    );
 
     for plugin in plugins {
         if cancel.is_cancelled() {
@@ -588,6 +601,7 @@ pub(super) async fn run_update_view(
             registry,
             &confirm_state,
             settings,
+            &silent_progress,
             &mut tally,
         )
         .await;
@@ -652,6 +666,7 @@ async fn process_one_update(
     registry: &PluginRegistry,
     confirm_state: &ConfirmState,
     settings: &SettingsController,
+    silent_progress: &ProgressEmitter,
     tally: &mut UpdateTally,
 ) {
     let name = plugin.manifest.name.clone();
@@ -696,25 +711,12 @@ async fn process_one_update(
     let needs_prompt = crate::confirm::update_needs_prompt(&remote.capabilities, &installed_caps);
     let caps_arg: Option<&[String]> = needs_prompt.then_some(&installed_caps);
 
-    // install_pipeline writes progress rows through ProgressEmitter; we
-    // wire a silent one here so those writes don't clobber the real
-    // launcher result list (which becomes visible again the moment the
-    // user Escs out of the update view). Setting `query_id = 0` against
-    // a latest_id pre-bumped to 1 makes every emit() short-circuit on
-    // the stale-check at the top of ProgressEmitter::emit.
-    let row_progress = ProgressEmitter::new(
-        0,
-        weak.clone(),
-        Arc::new(Mutex::new(Vec::new())),
-        Arc::new(AtomicU64::new(1)),
-    );
-
     let result = install_pipeline(
         &manifest_url,
         &format!("update-{name}"),
         caps_arg,
         registry,
-        &row_progress,
+        silent_progress,
         confirm_state,
         weak,
         settings,
@@ -757,7 +759,7 @@ where
             tracing::error!("update: host_view lock poisoned during update");
             return;
         };
-        let Some(HostViewState::Update(state)) = guard.as_mut() else {
+        let Some(state) = guard.as_mut() else {
             return;
         };
         mutate(state);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -384,16 +384,8 @@ fn tear_down_views(
     weak: &slint::Weak<QueryWindow>,
     reason: &'static str,
 ) {
-    let host_view_was_live = if let Ok(mut guard) = host_view.lock() {
-        if let Some(state) = guard.take() {
-            state.cancel.cancel();
-            true
-        } else {
-            false
-        }
-    } else {
-        false
-    };
+    let host_view_was_live = host_view::take_and_cancel(host_view);
+
     tear_down_js_views(
         view_close_signals,
         view_event_senders,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -10,8 +10,10 @@
 //! - `callbacks` — Slint window-callback wiring.
 //! - `query` — per-keystroke streaming dispatch + result rendering.
 //! - `install_flow` — install / update / reload host-task pipeline.
+//! - `host_view` — host-driven view-frame painting (update progress).
 
 mod callbacks;
+mod host_view;
 mod install_flow;
 mod query;
 
@@ -56,6 +58,9 @@ pub(super) enum HostMessage {
         input: String,
     },
     Task(actions::HostTask),
+    /// Run the update-all pipeline, streaming progress into the host-driven
+    /// update view (the slot was seeded before this message was sent).
+    UpdateAll,
     Shutdown,
     /// Drive a freshly-pushed view frame through its `setup → first render
     /// → mounted` sequence. Sent by `callbacks::push_view_frame`. The
@@ -115,6 +120,7 @@ pub fn start(
     let history_state = Arc::new(Mutex::new(QueryHistoryState::new(initial_entries)));
 
     let view_stack = Arc::new(Mutex::new(ViewStack::new()));
+    let host_view = host_view::new_slot();
 
     spawn_runtime_thread(
         rx,
@@ -126,6 +132,7 @@ pub fn start(
         Arc::clone(&confirm_state),
         settings.clone(),
         Arc::clone(&view_stack),
+        Arc::clone(&host_view),
         tx.clone(),
     )?;
 
@@ -141,6 +148,7 @@ pub fn start(
             history_db,
             history_state,
             view_stack,
+            host_view,
         },
     );
 
@@ -160,6 +168,7 @@ fn spawn_runtime_thread(
     confirm_state: ConfirmState,
     settings: SettingsController,
     view_stack: Arc<Mutex<ViewStack>>,
+    host_view: host_view::HostView,
     host_tx: mpsc::UnboundedSender<HostMessage>,
 ) -> Result<(), Box<dyn Error>> {
     thread::Builder::new()
@@ -234,36 +243,14 @@ fn spawn_runtime_thread(
                             if let Some(prev) = current_cancel.take() {
                                 prev.cancel();
                             }
-                            // Any host task (reload / install / update)
-                            // can swap the QuickJS context a view is
-                            // attached to. Tear down every open frame
-                            // first so plugins get a clean `unmounted`
-                            // call before their old context dies.
-                            for ((plugin, handle), signal) in view_close_signals.drain() {
-                                tracing::info!(
-                                    %plugin,
-                                    handle,
-                                    reason = "host task",
-                                    "views: tearing down",
-                                );
-                                signal.cancel();
-                            }
-                            view_event_senders.clear();
-
-                            if !view_stack.lock().map_or(true, |s| s.depth() == 0) {
-                                let view_stack_for_clear = Arc::clone(&view_stack);
-                                let weak_for_clear = weak.clone();
-                                slint::invoke_from_event_loop(move || {
-                                    if let Ok(mut stack) = view_stack_for_clear.lock() {
-                                        stack.clear();
-                                    }
-
-                                    if let Some(w) = weak_for_clear.upgrade() {
-                                        w.invoke_show_query();
-                                    }
-                                })
-                                .log_debug("views: host-task stack clear");
-                            }
+                            tear_down_views(
+                                &mut view_close_signals,
+                                &mut view_event_senders,
+                                &view_stack,
+                                &host_view,
+                                &weak,
+                                "host task",
+                            );
                             // Bump the query id so any stale yield from the
                             // last keystroke can't paint over the progress
                             // rows the task is about to push.
@@ -280,6 +267,39 @@ fn spawn_runtime_thread(
                                 progress,
                                 Arc::clone(&confirm_state),
                                 weak.clone(),
+                                &settings,
+                            )
+                            .await;
+                        }
+                        HostMessage::UpdateAll => {
+                            if let Some(prev) = current_cancel.take() {
+                                prev.cancel();
+                            }
+                            // JS views must die before the runtime kicks off
+                            // an update — the same reasoning as HostMessage::Task.
+                            // The host view slot was seeded by the Slint
+                            // thread before this message arrived; don't
+                            // touch it here, and don't switch the window
+                            // away from VIEW-VIEWS where it already lives.
+                            tear_down_js_views(
+                                &mut view_close_signals,
+                                &mut view_event_senders,
+                                &view_stack,
+                                &weak,
+                                "update view",
+                                ShowQueryAfter::No,
+                            );
+                            // Bump the query id for the same stale-yield
+                            // reason as HostMessage::Task — even though the
+                            // update view doesn't paint into the result list,
+                            // the launcher view shouldn't show stale rows
+                            // from the query that preceded the `update` pick.
+                            latest_id.fetch_add(1, Ordering::Relaxed);
+                            install_flow::run_update_view(
+                                &registry,
+                                Arc::clone(&host_view),
+                                weak.clone(),
+                                Arc::clone(&confirm_state),
                                 &settings,
                             )
                             .await;
@@ -346,6 +366,102 @@ fn spawn_runtime_thread(
             });
         })?;
     Ok(())
+}
+
+/// Tear down every open JS view frame and any live host view, firing
+/// each cancel signal so the underlying tasks (`spawn_view` for JS,
+/// `run_update_view` for host) clean up. Switches the window back to
+/// VIEW-QUERY when anything was live. Used before a launcher-row host
+/// task (install/reload) repaints the launcher view list.
+fn tear_down_views(
+    view_close_signals: &mut std::collections::HashMap<(String, u64), CancellationToken>,
+    view_event_senders: &mut std::collections::HashMap<
+        (String, u64),
+        mpsc::UnboundedSender<crate::plugins::runtime::ViewEventEnvelope>,
+    >,
+    view_stack: &Arc<Mutex<ViewStack>>,
+    host_view: &host_view::HostView,
+    weak: &slint::Weak<QueryWindow>,
+    reason: &'static str,
+) {
+    let host_view_was_live = if let Ok(mut guard) = host_view.lock() {
+        if let Some(state) = guard.take() {
+            state.cancel_token().cancel();
+            true
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+    tear_down_js_views(
+        view_close_signals,
+        view_event_senders,
+        view_stack,
+        weak,
+        reason,
+        ShowQueryAfter::Yes {
+            include_when_stack_empty: host_view_was_live,
+        },
+    );
+}
+
+/// What to do with `current-view` once JS-stack teardown finishes.
+#[derive(Clone, Copy)]
+enum ShowQueryAfter {
+    /// Switch the window to VIEW-QUERY. If the JS stack was empty,
+    /// `include_when_stack_empty` decides whether to still send the
+    /// show-query (true when a host view was live and just got closed).
+    Yes { include_when_stack_empty: bool },
+    /// Don't touch `current-view` — the caller (typically the update
+    /// flow) wants the host view it seeded to stay visible.
+    No,
+}
+
+/// JS-stack teardown — fires close signals, drains the stack, optionally
+/// flips the window back to VIEW-QUERY. The update flow uses this with
+/// `route_back_to_query = false` so the host view it just seeded keeps
+/// VIEW-VIEWS on screen.
+fn tear_down_js_views(
+    view_close_signals: &mut std::collections::HashMap<(String, u64), CancellationToken>,
+    view_event_senders: &mut std::collections::HashMap<
+        (String, u64),
+        mpsc::UnboundedSender<crate::plugins::runtime::ViewEventEnvelope>,
+    >,
+    view_stack: &Arc<Mutex<ViewStack>>,
+    weak: &slint::Weak<QueryWindow>,
+    reason: &'static str,
+    show_query_after: ShowQueryAfter,
+) {
+    for ((plugin, handle), signal) in view_close_signals.drain() {
+        tracing::info!(%plugin, handle, %reason, "views: tearing down");
+        signal.cancel();
+    }
+    view_event_senders.clear();
+
+    let stack_was_non_empty = !view_stack.lock().map_or(true, |s| s.depth() == 0);
+    let route_back = match show_query_after {
+        ShowQueryAfter::Yes {
+            include_when_stack_empty,
+        } => stack_was_non_empty || include_when_stack_empty,
+        ShowQueryAfter::No => false,
+    };
+
+    if !stack_was_non_empty && !route_back {
+        return;
+    }
+    let view_stack_for_clear = Arc::clone(view_stack);
+    let weak_for_clear = weak.clone();
+    slint::invoke_from_event_loop(move || {
+        if let Ok(mut stack) = view_stack_for_clear.lock() {
+            stack.clear();
+        }
+
+        if route_back && let Some(w) = weak_for_clear.upgrade() {
+            w.invoke_show_query();
+        }
+    })
+    .log_debug("views: host-task stack clear");
 }
 
 /// Open the query-history DB at the platform default path. Returns `None` on

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -287,7 +287,7 @@ fn spawn_runtime_thread(
                                 &view_stack,
                                 &weak,
                                 "update view",
-                                ShowQueryAfter::No,
+                                false,
                             );
                             // Bump the query id for the same stale-yield
                             // reason as HostMessage::Task — even though the
@@ -386,7 +386,7 @@ fn tear_down_views(
 ) {
     let host_view_was_live = if let Ok(mut guard) = host_view.lock() {
         if let Some(state) = guard.take() {
-            state.cancel_token().cancel();
+            state.cancel.cancel();
             true
         } else {
             false
@@ -400,28 +400,15 @@ fn tear_down_views(
         view_stack,
         weak,
         reason,
-        ShowQueryAfter::Yes {
-            include_when_stack_empty: host_view_was_live,
-        },
+        host_view_was_live,
     );
 }
 
-/// What to do with `current-view` once JS-stack teardown finishes.
-#[derive(Clone, Copy)]
-enum ShowQueryAfter {
-    /// Switch the window to VIEW-QUERY. If the JS stack was empty,
-    /// `include_when_stack_empty` decides whether to still send the
-    /// show-query (true when a host view was live and just got closed).
-    Yes { include_when_stack_empty: bool },
-    /// Don't touch `current-view` — the caller (typically the update
-    /// flow) wants the host view it seeded to stay visible.
-    No,
-}
-
 /// JS-stack teardown — fires close signals, drains the stack, optionally
-/// flips the window back to VIEW-QUERY. The update flow uses this with
-/// `route_back_to_query = false` so the host view it just seeded keeps
-/// VIEW-VIEWS on screen.
+/// flips the window back to VIEW-QUERY. The update flow passes
+/// `route_back_when_idle = false` so the host view it just seeded keeps
+/// VIEW-VIEWS on screen; the install/reload flow passes `true` to bring
+/// the launcher back into view when a host view was just closed.
 fn tear_down_js_views(
     view_close_signals: &mut std::collections::HashMap<(String, u64), CancellationToken>,
     view_event_senders: &mut std::collections::HashMap<
@@ -431,7 +418,7 @@ fn tear_down_js_views(
     view_stack: &Arc<Mutex<ViewStack>>,
     weak: &slint::Weak<QueryWindow>,
     reason: &'static str,
-    show_query_after: ShowQueryAfter,
+    route_back_when_idle: bool,
 ) {
     for ((plugin, handle), signal) in view_close_signals.drain() {
         tracing::info!(%plugin, handle, %reason, "views: tearing down");
@@ -440,12 +427,7 @@ fn tear_down_js_views(
     view_event_senders.clear();
 
     let stack_was_non_empty = !view_stack.lock().map_or(true, |s| s.depth() == 0);
-    let route_back = match show_query_after {
-        ShowQueryAfter::Yes {
-            include_when_stack_empty,
-        } => stack_was_non_empty || include_when_stack_empty,
-        ShowQueryAfter::No => false,
-    };
+    let route_back = stack_was_non_empty || route_back_when_idle;
 
     if !stack_was_non_empty && !route_back {
         return;

--- a/src/plugins/actions.rs
+++ b/src/plugins/actions.rs
@@ -15,12 +15,14 @@ use crate::plugins::result::Action;
 /// `HideWindow` is the default — invoking the row's action removes the
 /// reason the launcher is on screen, so we close it. `KeepOpen` is for
 /// in-window navigation actions like `OpenSettings`, which switch views
-/// rather than dismissing. `HostTask` is the install/update/reload path —
+/// rather than dismissing. `HostTask` is the install/reload path —
 /// the action couldn't be executed inline because it needs the tokio
 /// runtime; the caller forwards the task to the runtime thread instead.
 /// `ShowView` / `CloseView` route into the view-stack the caller owns —
 /// the action layer is pure; stack mutation happens in `app::callbacks`
-/// where the picked row's plugin name is in scope.
+/// where the picked row's plugin name is in scope. `ShowUpdateView` opens
+/// the host-driven progress view and kicks off the update loop on the
+/// runtime thread.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ActionOutcome {
     HideWindow,
@@ -33,19 +35,19 @@ pub enum ActionOutcome {
         reset: bool,
     },
     CloseView,
+    ShowUpdateView,
 }
 
 /// Host-side maintenance tasks the runtime thread executes off the back of
-/// pressing Enter on a Core verb row.
+/// pressing Enter on a Core verb row. `update` doesn't appear here — it
+/// flows through [`ActionOutcome::ShowUpdateView`] so the Slint thread can
+/// open the host view before the runtime thread starts the update loop.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HostTask {
     /// `None` ⇒ reload every plugin; `Some(name)` ⇒ reload just that one.
     Reload { name: Option<String> },
     /// Install a plugin from the given manifest URL.
     Install { url: String },
-    /// Iterate every plugin with a `manifestUrl` and install any newer
-    /// remote version.
-    UpdateAll,
 }
 
 /// Execute an action.
@@ -82,7 +84,7 @@ pub fn execute(action: &Action) -> Result<ActionOutcome, Box<dyn Error>> {
         Action::OpenSettings => Ok(ActionOutcome::OpenSettingsView),
         Action::ReloadPlugin { name } => Ok(ActionOutcome::HostTask(HostTask::Reload { name: name.clone() })),
         Action::InstallPlugin { url } => Ok(ActionOutcome::HostTask(HostTask::Install { url: url.clone() })),
-        Action::UpdatePlugins => Ok(ActionOutcome::HostTask(HostTask::UpdateAll)),
+        Action::UpdatePlugins => Ok(ActionOutcome::ShowUpdateView),
         // Noop preserved the pre-outcome behaviour of hiding the window —
         // the launcher closes after Enter, even on a `Noop` row like the
         // version readout, because the user explicitly chose to act.
@@ -168,9 +170,9 @@ mod tests {
     }
 
     #[test]
-    fn update_action_yields_host_task() {
+    fn update_action_yields_show_update_view() {
         let outcome = execute(&Action::UpdatePlugins).expect("execute");
-        assert_eq!(outcome, ActionOutcome::HostTask(HostTask::UpdateAll));
+        assert_eq!(outcome, ActionOutcome::ShowUpdateView);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The `update` Core verb previously streamed per-plugin status into the launcher's result list — capped at 9 visible rows, no progress bars, no version diffs. Routes it through the view-frame system (PR #24) instead.
- Adds a Rust-driven host view path next to the existing JS plugin view stack: a `HostView` slot, an `UpdateViewState` with per-plugin entries, and a `paint_update` that builds heading + progress bar + per-plugin text + spinner + summary as `ViewBlock`s.
- Esc closes the host view and fires its cancel token so the runtime-thread update loop bails on the next plugin boundary. Confirm-view prompts during an update return to the host view instead of the launcher.

## Test plan

- [x] `cargo fmt --check`, `just lint`, `just lint-pedantic` clean
- [x] `cargo test` — 268 lib + integration tests pass
- [x] `cargo build` clean
- [ ] `just run`, type `update`, confirm: view opens with title + progress bar + per-plugin rows; Esc cancels in-flight; summary appears on completion
- [ ] `install <url>` / `reload` paths still stream rows into the launcher unchanged
- [ ] Capability-prompt branch (manifest with new caps) shows the confirm view mid-update and returns to the host view after the decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)