### PR TITLE
fix(app-launcher): descend into macOS app subdirectories

### DIFF
--- a/plugins/app-launcher/app-launcher.test.js
+++ b/plugins/app-launcher/app-launcher.test.js
@@ -16,18 +16,29 @@ function dirEntry(path, name) {
     return { name, path, isFile: false, isDir: true };
 }
 
+function fileEntry(path, name) {
+    return { name, path, isFile: true, isDir: false };
+}
+
 const MAC_FIXTURES = {
     '/Applications': [
         dirEntry('/Applications/Safari.app', 'Safari.app'),
         dirEntry('/Applications/Calculator.app', 'Calculator.app'),
-        dirEntry('/Applications/README.txt', 'README.txt'),
+        fileEntry('/Applications/README.txt', 'README.txt'),
     ],
     '/System/Applications': [
         dirEntry('/System/Applications/Terminal.app', 'Terminal.app'),
+        dirEntry('/System/Applications/Utilities', 'Utilities'),
+    ],
+    '/System/Applications/Utilities': [
+        dirEntry(
+            '/System/Applications/Utilities/Activity Monitor.app',
+            'Activity Monitor.app',
+        ),
     ],
     '/System/Library/CoreServices': [
         dirEntry('/System/Library/CoreServices/Finder.app', 'Finder.app'),
-        dirEntry(
+        fileEntry(
             '/System/Library/CoreServices/SystemUIServer',
             'SystemUIServer',
         ),
@@ -147,6 +158,17 @@ describe('app-launcher macOS', () => {
         );
         // README.txt would match "readme" if not filtered.
         expect(results).toEqual([]);
+    });
+
+    test('descends into subdirs like /System/Applications/Utilities', async () => {
+        const { plugin } = await loadPlugin();
+        const results = await collect(
+            plugin.query('activity', { aborted: false }),
+        );
+        expect(results.length).toBeGreaterThan(0);
+        expect(results[0].key).toBe(
+            '/System/Applications/Utilities/Activity Monitor.app',
+        );
     });
 });
 

--- a/plugins/app-launcher/manifest.json
+++ b/plugins/app-launcher/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "app-launcher",
   "displayName": "App Launcher",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Find and open installed applications",
   "debounceMs": 100,
   "timeoutMs": 800,

--- a/plugins/app-launcher/package.json
+++ b/plugins/app-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@high-beam-plugin/app-launcher",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "test": "vitest run"

--- a/plugins/app-launcher/plugin.js
+++ b/plugins/app-launcher/plugin.js
@@ -23,6 +23,10 @@ const APP_EXT = ".app";
 const DESKTOP_EXT = ".desktop";
 const RESULT_LIMIT = 10;
 const SCORE_THRESHOLD = 0.05;
+// Catches one level of grouping like `/System/Applications/Utilities` or
+// `/Applications/Setapp` without descending into `.app` bundles themselves
+// (those would expose thousands of internal files to readDir).
+const MAC_MAX_DEPTH = 2;
 
 // Module-level cache — scanning these dirs is hundreds of ms; the host
 // re-imports rarely, so this survives across queries.
@@ -35,24 +39,39 @@ function basenameWithoutExt(path, ext) {
 }
 
 
-async function collectMacApps() {
-    const apps = [];
-    for (const dir of MAC_APP_DIRECTORIES) {
-        try {
-            for await (const entry of readDir(dir, { recursive: false })) {
-                // Filter on basename — `.app` bundles flip between file vs
-                // dir depending on filesystem.
-                const name = entry.name ?? "";
-                if (!name.endsWith(APP_EXT)) continue;
+async function walkMacAppDir(dir, depth, apps) {
+    const subdirs = [];
+    try {
+        for await (const entry of readDir(dir, { recursive: false })) {
+            // Filter on basename — `.app` bundles flip between file vs
+            // dir depending on filesystem.
+            const name = entry.name ?? "";
+            if (name.endsWith(APP_EXT)) {
                 apps.push({
                     kind: "mac",
                     path: entry.path,
                     appName: basenameWithoutExt(entry.path, APP_EXT),
                 });
+                continue;
             }
-        } catch {
-            // Missing dirs are normal (~/Applications, older macOS layouts).
+            if (depth >= MAC_MAX_DEPTH) continue;
+            if (!entry.isDir) continue;
+            if (name.startsWith(".")) continue;
+            subdirs.push(entry.path);
         }
+    } catch {
+        // Missing dirs are normal (~/Applications, older macOS layouts).
+        return;
+    }
+    for (const subdir of subdirs) {
+        await walkMacAppDir(subdir, depth + 1, apps);
+    }
+}
+
+async function collectMacApps() {
+    const apps = [];
+    for (const dir of MAC_APP_DIRECTORIES) {
+        await walkMacAppDir(dir, 0, apps);
     }
     return apps;
 }


### PR DESCRIPTION
## Summary
- `collectMacApps` did a flat `readDir`, so apps living under grouping folders were silently missing from the index — e.g. `/System/Applications/Utilities/Activity Monitor.app`, `/System/Library/CoreServices/Applications/Keychain Access.app`, anything under `/Applications/Setapp/`, etc.
- Replaced the flat loop with a depth-limited recursive walk (`MAC_MAX_DEPTH = 2`) that descends into non-`.app` subdirectories but stops before walking into `.app` bundle internals (which would expose thousands of files).
- Bumped `app-launcher` plugin from `0.1.0` → `0.1.1` (in both `manifest.json` and `package.json`).

## Test plan
- [x] `npx vitest run` in `plugins/app-launcher/` — 11 passing (10 existing + 1 new test asserting `/System/Applications/Utilities/Activity Monitor.app` is found).
- [ ] Manually verify in a built app that Activity Monitor / Keychain Access show up when searched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)