### PR TITLE
feat(packaging): scaffold Homebrew cask + universal2 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,3 +347,48 @@ jobs:
             dist/linux/**/*.deb
             dist/linux/**/*.rpm
             dist/linux/**/*.tar.gz
+
+      # Auto-bump the Homebrew cask: compute the universal .dmg's sha256 and
+      # push the resolved version + digest to the tap repo, so
+      # `brew install --cask` tracks each release without a manual edit. The
+      # in-repo Casks/high-beam.rb stays a template (placeholder sha) — we
+      # copy it, pin version + sha, and commit the result to the tap.
+      #
+      # Gated on HOMEBREW_TAP_TOKEN (a PAT with contents:write on
+      # Mechazawa/homebrew-high-beam); absent → no-op, same opt-in pattern as
+      # signing. Pre-release tags are skipped so the tap only points at stable.
+      - name: Update Homebrew tap cask
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        if: >-
+          env.HOMEBREW_TAP_TOKEN != ''
+          && !contains(github.ref_name, '-rc')
+          && !contains(github.ref_name, '-beta')
+          && !contains(github.ref_name, '-alpha')
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          dmg="$(ls dist/macos/HighBeam_*_universal.dmg | head -1)"
+          sha="$(sha256sum "$dmg" | cut -d' ' -f1)"
+          echo "Bumping high-beam cask to ${version} (${sha})"
+
+          git clone --depth 1 \
+              "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/Mechazawa/homebrew-high-beam.git" \
+              tap
+          mkdir -p tap/Casks
+          # Carry over any non-version cask edits (caveats/zap/livecheck) from
+          # the in-repo source of truth, then pin the two volatile fields.
+          cp packaging/homebrew/Casks/high-beam.rb tap/Casks/high-beam.rb
+          sed -i -E "s/^  version \".*\"/  version \"${version}\"/" tap/Casks/high-beam.rb
+          sed -i -E "s/^  sha256 \".*\"/  sha256 \"${sha}\"/"       tap/Casks/high-beam.rb
+
+          cd tap
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- Casks/high-beam.rb; then
+            echo "Cask already up to date; nothing to push."
+          else
+            git add Casks/high-beam.rb
+            git commit -m "high-beam ${version}"
+            git push
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,15 +93,17 @@ jobs:
 
           rm -f "$CERT_PATH"
 
-      - name: Build .app + .dmg
-        run: just bundle
+      # Universal2 build: one .dmg that runs on Apple Silicon + Intel, so
+      # the Homebrew cask needs a single url + sha256 (no arch branches).
+      - name: Build universal .app + .dmg
+        run: just bundle-universal
 
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v5
         with:
           name: macos
           path: |
-            target/release/HighBeam_*.dmg
+            target/release/HighBeam_*_universal.dmg
             target/release/HighBeam.app
           if-no-files-found: error
 

--- a/Justfile
+++ b/Justfile
@@ -34,6 +34,37 @@ bundle:
     cargo build --release
     cargo packager --release
 
+# Universal2 (arm64 + x86_64) .app + .dmg for the Homebrew cask.
+#
+# cargo-packager packages whatever binary already sits at
+# `target/release/high-beam`, so we build both arches separately and
+# `lipo` them into that path before packaging. The result is one fat
+# binary that runs on Apple Silicon and Intel from a single download —
+# which keeps the cask to one `url` + one `sha256` instead of arch
+# branches. macOS-only (lipo + the Apple toolchain); run on a Mac.
+#
+# The dmg cargo-packager emits is named after the *host* arch
+# (`HighBeam_<ver>_aarch64.dmg` on a CI arm runner) even though the
+# payload is universal, so we rename it to `_universal` for an honest,
+# stable cask URL.
+bundle-universal:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    rustup target add aarch64-apple-darwin x86_64-apple-darwin
+    cargo build --release --target aarch64-apple-darwin
+    cargo build --release --target x86_64-apple-darwin
+    mkdir -p target/release
+    lipo -create -output target/release/high-beam \
+        target/aarch64-apple-darwin/release/high-beam \
+        target/x86_64-apple-darwin/release/high-beam
+    cargo packager --release --formats app dmg
+    version="$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)"
+    src="$(ls target/release/HighBeam_${version}_*.dmg | head -1)"
+    dest="target/release/HighBeam_${version}_universal.dmg"
+    [ "$src" = "$dest" ] || mv "$src" "$dest"
+    echo "-> $dest"
+    shasum -a 256 "$dest"
+
 # Build every Linux artifact. Run this on a Linux host — cargo-packager
 # silently skips deb/pacman when the host is macOS.
 bundle-linux: bundle-tarball bundle-deb bundle-arch bundle-rpm

--- a/README.md
+++ b/README.md
@@ -10,12 +10,20 @@ Pre-release.
 
 ## Install
 
+macOS (Homebrew tap):
+
+```
+brew install --cask mechazawa/high-beam/high-beam
+```
+
+From source:
+
 ```
 cargo install --path .
 ```
 
 Packaged builds (.app, .dmg, .deb, .pacman, .rpm, tarball) via
-`just bundle` / `just bundle-linux`. See
+`just bundle` / `just bundle-universal` / `just bundle-linux`. See
 [docs/distribution.md](docs/distribution.md).
 
 macOS post-install:

--- a/bundle/Info.plist
+++ b/bundle/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>NSHumanReadableCopyright</key>
-    <string>Bas Bieling — MIT licensed</string>
+    <string>Bas Bieling — GPL-3.0-or-later</string>
     <key>NSSupportsAutomaticGraphicsSwitching</key>
     <true/>
     <key>NSPrincipalClass</key>

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -100,6 +100,28 @@ the packager wraps `xcrun notarytool` + `stapler` directly. Apple's
 [Notarizing macOS software](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution)
 docs cover the cert + notarytool setup.
 
+## Homebrew (macOS)
+
+High Beam ships through a **personal tap** as a cask (it's a GUI `.app`,
+so `homebrew/core` is out, and the official `homebrew/cask` repo gates on
+notability + notarization we don't clear yet):
+
+```sh
+brew install --cask mechazawa/high-beam/high-beam
+```
+
+The cask pins a **universal2 `.dmg`** — `just bundle-universal` lipo-joins
+the arm64 + x86_64 release binaries into one `.app` so a single download
+covers every Mac (one `url`, one `sha256`, no arch branches). The macOS
+release job runs this recipe instead of `just bundle`.
+
+The cask source of truth and the publish workflow (first-time tap setup,
+per-release `version` + `sha256` bump, and the remaining gates for an
+eventual `homebrew/cask` submission) live under
+[`packaging/homebrew/`](../packaging/homebrew/README.md). Because the app
+is still self-signed, the cask carries the `xattr -dr
+com.apple.quarantine` step as a `caveats` note until notarization lands.
+
 ## Linux
 
 Four shipped package formats, in the user-stated priority order. The

--- a/packaging/homebrew/Casks/high-beam.rb
+++ b/packaging/homebrew/Casks/high-beam.rb
@@ -7,16 +7,18 @@
 # Install once the tap is published:
 #   brew install --cask mechazawa/high-beam/high-beam
 #
-# The `sha256` below MUST be refreshed every release — it pins the
-# universal .dmg `just bundle-universal` uploads to GitHub Releases.
-# `just bundle-universal` prints the digest at the end of its run, or:
-#   shasum -a 256 HighBeam_<version>_universal.dmg
+# This file is the TEMPLATE / source of truth. The release workflow
+# (.github/workflows/release.yml § "Update Homebrew tap cask") copies it
+# to the tap repo on every stable tag, rewriting `version` + `sha256` to
+# the freshly built universal .dmg. So the placeholders below are
+# expected here and never need a manual edit — only the non-version
+# fields (caveats/zap/livecheck/desc) are hand-maintained in this copy.
 cask "high-beam" do
+  # version/sha256 are placeholders in this template; the release
+  # workflow pins them to the published universal .dmg when it syncs
+  # this file into the tap. (To bump by hand instead, set both and copy
+  # to tap Casks/: `shasum -a 256 HighBeam_<version>_universal.dmg`.)
   version "0.3.1"
-  # PLACEHOLDER — replace with the real digest of the universal .dmg for
-  # this `version` before publishing. No universal artifact has been cut
-  # yet (current releases ship an arm64-only .dmg), so this stays fake
-  # until the first release built by the updated workflow lands.
   sha256 "0000000000000000000000000000000000000000000000000000000000000000"
 
   url "https://github.com/Mechazawa/high-beam/releases/download/v#{version}/HighBeam_#{version}_universal.dmg",

--- a/packaging/homebrew/Casks/high-beam.rb
+++ b/packaging/homebrew/Casks/high-beam.rb
@@ -1,0 +1,58 @@
+# High Beam — Homebrew cask (personal tap).
+#
+# Lives in the tap repo `Mechazawa/homebrew-high-beam` as
+# `Casks/high-beam.rb`; this copy under packaging/ is the source of
+# truth we edit in-tree and mirror out on release (see README.md here).
+#
+# Install once the tap is published:
+#   brew install --cask mechazawa/high-beam/high-beam
+#
+# The `sha256` below MUST be refreshed every release — it pins the
+# universal .dmg `just bundle-universal` uploads to GitHub Releases.
+# `just bundle-universal` prints the digest at the end of its run, or:
+#   shasum -a 256 HighBeam_<version>_universal.dmg
+cask "high-beam" do
+  version "0.3.1"
+  # PLACEHOLDER — replace with the real digest of the universal .dmg for
+  # this `version` before publishing. No universal artifact has been cut
+  # yet (current releases ship an arm64-only .dmg), so this stays fake
+  # until the first release built by the updated workflow lands.
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+
+  url "https://github.com/Mechazawa/high-beam/releases/download/v#{version}/HighBeam_#{version}_universal.dmg",
+      verified: "github.com/Mechazawa/high-beam/"
+  name "High Beam"
+  desc "Keyboard launcher in the Spotlight / Alfred / Raycast / Ulauncher class"
+  homepage "https://github.com/Mechazawa/high-beam"
+
+  # GitHub Releases tags are `vX.Y.Z`; strip the leading `v` for the
+  # cask version. Pre-release tags (-rc/-beta/-alpha) are flagged as
+  # prereleases upstream and skipped by :github_latest automatically.
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  # minimum-system-version = "14.0" in Cargo.toml's packager.macos table.
+  depends_on macos: ">= :sonoma"
+
+  app "HighBeam.app"
+
+  # `directories::ProjectDirs` with empty qualifier/org resolves to
+  # ~/Library/Application Support/high-beam on macOS (src/paths.rs) — it
+  # holds settings, the single-instance socket, and the seeded plugins/
+  # + themes/ trees.
+  zap trash: [
+    "~/Library/Application Support/high-beam",
+  ]
+
+  caveats <<~EOS
+    HighBeam is currently self-signed (not Apple-notarized), so the
+    first launch is blocked by Gatekeeper. Until a notarized build
+    ships, strip the download quarantine once after install:
+
+      xattr -dr com.apple.quarantine "#{appdir}/HighBeam.app"
+
+    Open with Shift+Space (configurable in Settings -> Global).
+  EOS
+end

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -31,8 +31,14 @@ expands to `github.com/Mechazawa/homebrew-high-beam`.
 ## First-time setup (once)
 
 1. Create the public repo `Mechazawa/homebrew-high-beam` on GitHub.
-2. Copy `Casks/high-beam.rb` into its `Casks/` directory and push.
-3. Verify end-to-end:
+2. Add a repo secret on **Mechazawa/High-Beam** named `HOMEBREW_TAP_TOKEN`
+   — a PAT (fine-grained, `contents: write` on `homebrew-high-beam`, or a
+   classic `repo`-scoped token). This is what lets the release workflow
+   push cask bumps into the tap.
+3. Seed the tap once so `brew tap` has something to read — either copy
+   `Casks/high-beam.rb` in by hand, or just cut one stable release and
+   let the workflow create it.
+4. Verify end-to-end:
 
    ```sh
    brew tap mechazawa/high-beam
@@ -40,26 +46,35 @@ expands to `github.com/Mechazawa/homebrew-high-beam`.
    brew uninstall --cask high-beam
    ```
 
-## Per-release update
+## Per-release update — automated
 
-The cask pins a universal `.dmg` and its SHA-256, so both move every
-release:
+`version` + `sha256` are bumped for you. On every **stable** `vX.Y.Z`
+tag, `.github/workflows/release.yml` (step "Update Homebrew tap cask"):
 
-1. Cut the release as usual (push a `vX.Y.Z` tag). The macOS job runs
-   `just bundle-universal`, which lipo-joins the arm64 + x86_64 binaries
-   into one universal2 `.app`, packages `HighBeam_<version>_universal.dmg`,
-   and uploads it to the GitHub Release.
-2. Grab the digest — `just bundle-universal` prints it, or:
+1. Builds `HighBeam_<version>_universal.dmg` via `just bundle-universal`.
+2. Computes its `sha256`.
+3. Copies this template into the tap repo, pins `version` + `sha256`, and
+   commits/pushes `high-beam <version>` to `Mechazawa/homebrew-high-beam`.
 
-   ```sh
-   shasum -a 256 HighBeam_<version>_universal.dmg
-   ```
+Pre-release tags (`-rc`/`-beta`/`-alpha`) and a missing `HOMEBREW_TAP_TOKEN`
+both skip the step — no manual sha edit in the normal path.
 
-3. Bump `version` and `sha256` in `Casks/high-beam.rb` here, then mirror
-   the file into the tap repo and push.
+The in-repo `Casks/high-beam.rb` stays a **template** with placeholder
+`version`/`sha256`; edit it only for the hand-maintained fields
+(`caveats`, `zap`, `livecheck`, `desc`) — those propagate to the tap on
+the next release.
+
+### Bumping by hand (fallback)
+
+If you ever need to bump without a tagged release:
+
+```sh
+shasum -a 256 HighBeam_<version>_universal.dmg
+# set version + sha256 in the tap repo's Casks/high-beam.rb, commit, push
+```
 
 `brew livecheck high-beam` reads GitHub Releases and reports when a newer
-tag exists, so the bump can be scripted later if desired.
+tag exists.
 
 ## Before validating with `brew audit`
 

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,82 @@
+# Homebrew distribution
+
+High Beam is a GUI `.app` shipped as a `.dmg`, so on Homebrew it is a
+**cask**, not a formula (`homebrew/core` does not accept GUI apps).
+
+We distribute through a **personal tap** rather than the official
+`homebrew/cask` repo. The official repo auto-rejects new casks that miss
+its notability bar (≥ 75 GitHub stars, or ≥ 30 forks/watchers) and that
+aren't Apple-notarized — neither of which High Beam clears yet. A tap has
+no such gate, so users can install today:
+
+```sh
+brew install --cask mechazawa/high-beam/high-beam
+```
+
+## Layout
+
+`Casks/high-beam.rb` here is the source of truth, edited in-tree
+alongside the code it packages (same convention as `packaging/aur/`). The
+live tap is a **separate GitHub repo** Homebrew clones on `brew tap`:
+
+```
+Mechazawa/homebrew-high-beam     # the tap repo (note the homebrew- prefix)
+└── Casks/
+    └── high-beam.rb             # a copy of this file
+```
+
+The `homebrew-` prefix is mandatory — `brew tap mechazawa/high-beam`
+expands to `github.com/Mechazawa/homebrew-high-beam`.
+
+## First-time setup (once)
+
+1. Create the public repo `Mechazawa/homebrew-high-beam` on GitHub.
+2. Copy `Casks/high-beam.rb` into its `Casks/` directory and push.
+3. Verify end-to-end:
+
+   ```sh
+   brew tap mechazawa/high-beam
+   brew install --cask high-beam
+   brew uninstall --cask high-beam
+   ```
+
+## Per-release update
+
+The cask pins a universal `.dmg` and its SHA-256, so both move every
+release:
+
+1. Cut the release as usual (push a `vX.Y.Z` tag). The macOS job runs
+   `just bundle-universal`, which lipo-joins the arm64 + x86_64 binaries
+   into one universal2 `.app`, packages `HighBeam_<version>_universal.dmg`,
+   and uploads it to the GitHub Release.
+2. Grab the digest — `just bundle-universal` prints it, or:
+
+   ```sh
+   shasum -a 256 HighBeam_<version>_universal.dmg
+   ```
+
+3. Bump `version` and `sha256` in `Casks/high-beam.rb` here, then mirror
+   the file into the tap repo and push.
+
+`brew livecheck high-beam` reads GitHub Releases and reports when a newer
+tag exists, so the bump can be scripted later if desired.
+
+## Before validating with `brew audit`
+
+```sh
+brew audit --cask --online mechazawa/high-beam/high-beam
+brew style mechazawa/high-beam/high-beam
+```
+
+## Path to the official homebrew/cask repo
+
+Two upstream gates remain before a `homebrew/cask` PR would be accepted:
+
+- **Notability** — the GitHub repo needs ≥ 75 stars (or ≥ 30 forks /
+  watchers). Tracked by traction, not code.
+- **Notarization** — replace the self-signed identity with an Apple
+  Developer ID cert and add an `xcrun notarytool submit` + `stapler`
+  step to `release.yml`, so the cask no longer needs the
+  `xattr -dr com.apple.quarantine` caveat. cargo-packager wraps
+  notarytool directly when `APPLE_*` credentials are present (see
+  `docs/distribution.md` § Signing).


### PR DESCRIPTION
Prep for Homebrew distribution via a personal tap. HighBeam is a GUI
.app, so it's a cask, not a homebrew/core formula; the official
homebrew/cask repo is gated on notability + notarization we don't clear
yet, so we ship through our own tap first.

- Justfile: add `bundle-universal` — lipo arm64 + x86_64 into one
  universal2 .app/.dmg so the cask needs a single url + sha256.
- release.yml: macOS job now builds the universal .dmg.
- packaging/homebrew/: cask source of truth + publish workflow README
  (mirrors the packaging/aur/ convention).
- Info.plist: NSHumanReadableCopyright said MIT; project is
  GPL-3.0-or-later — fixed.
- docs/distribution.md + README: document the brew tap install path.