### PR TITLE
fix(macos): hide daemon from Dock / Cmd-Tab

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,8 +242,7 @@ global-hotkey = "0.8"
 objc2 = "0.5"
 objc2-app-kit = { version = "0.2", features = [
     "NSApplication",
-    # `setActivationPolicy:` + the `NSApplicationActivationPolicy` enum live
-    # behind this feature, used to drop the daemon out of the Dock/Cmd-Tab.
+    # `setActivationPolicy` (accessory app, no Dock icon) lives behind this.
     "NSRunningApplication",
     "NSView",
     "NSWindow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,7 +243,7 @@ objc2 = "0.5"
 objc2-app-kit = { version = "0.2", features = [
     "NSApplication",
     # `setActivationPolicy:` + the `NSApplicationActivationPolicy` enum live
-    # behind this feature — used to drop the daemon out of the Dock/Cmd-Tab.
+    # behind this feature, used to drop the daemon out of the Dock/Cmd-Tab.
     "NSRunningApplication",
     "NSView",
     "NSWindow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,6 +242,9 @@ global-hotkey = "0.8"
 objc2 = "0.5"
 objc2-app-kit = { version = "0.2", features = [
     "NSApplication",
+    # `setActivationPolicy:` + the `NSApplicationActivationPolicy` enum live
+    # behind this feature — used to drop the daemon out of the Dock/Cmd-Tab.
+    "NSRunningApplication",
     "NSView",
     "NSWindow",
 ] }

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -159,13 +159,18 @@ prevention kicks in). The window-event handler in `src/window.rs`
 debounces blurs by `BLUR_GRACE_MS` so the launcher doesn't auto-hide
 during the activation handoff.
 
-### Dock / Cmd-Tab hiding is still TODO
+### Dock / Cmd-Tab hiding
 
 `activate(ignoringOtherApps:)` + `makeKeyAndOrderFront:` only govern
-frontmost/key state. To hide from Dock / Cmd-Tab we'd need
-`NSApp.setActivationPolicy(.accessory)` or `LSUIElement=1` in
-`Info.plist` when we ship a real `.app`. Currently a no-op TODO in
-`src/window.rs`.
+frontmost/key state. To stay out of the Dock / Cmd-Tab the daemon runs
+as an accessory app: `daemon::run` calls `window::hide_from_dock`, which
+schedules `NSApp.setActivationPolicy(.accessory)` onto the event loop via
+`invoke_from_event_loop`. It is scheduled rather than called inline
+because winit's `applicationDidFinishLaunching` forces `.regular` for an
+unbundled `cargo run` and would clobber an earlier call. Packaged `.app`
+builds reach the same state through `background-app = true` (`LSUIElement`
+in `Info.plist`), which winit leaves untouched. Accessory apps still
+become key/frontmost, so the activation dance above is unaffected.
 
 ## Why not WASM for plugins
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -140,8 +140,8 @@ pub fn run(options: Options) -> Result<(), Box<dyn Error>> {
     // settings UI is writing.
     window::configure(&window, settings_controller.clone());
 
-    // Drop the daemon out of the Dock / Cmd-Tab (macOS accessory app). Safe
-    // before the loop runs: it schedules onto the event loop, see the fn doc.
+    // Keep the daemon out of the Dock / Cmd-Tab (macOS accessory app).
+    #[cfg(target_os = "macos")]
     window::hide_from_dock();
 
     // Keep the host alive for the daemon's lifetime; `Drop` sends Shutdown.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -140,6 +140,10 @@ pub fn run(options: Options) -> Result<(), Box<dyn Error>> {
     // settings UI is writing.
     window::configure(&window, settings_controller.clone());
 
+    // Drop the daemon out of the Dock / Cmd-Tab (macOS accessory app). Safe
+    // before the loop runs — it schedules onto the event loop, see the fn doc.
+    window::hide_from_dock();
+
     // Keep the host alive for the daemon's lifetime; `Drop` sends Shutdown.
     let _plugin_host = app::start(&window, options.plugins_dir.clone(), settings_controller.clone())?;
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -141,7 +141,7 @@ pub fn run(options: Options) -> Result<(), Box<dyn Error>> {
     window::configure(&window, settings_controller.clone());
 
     // Drop the daemon out of the Dock / Cmd-Tab (macOS accessory app). Safe
-    // before the loop runs — it schedules onto the event loop, see the fn doc.
+    // before the loop runs: it schedules onto the event loop, see the fn doc.
     window::hide_from_dock();
 
     // Keep the host alive for the daemon's lifetime; `Drop` sends Shutdown.

--- a/src/window.rs
+++ b/src/window.rs
@@ -185,17 +185,14 @@ pub(crate) fn configure(window: &QueryWindow, settings: SettingsController) {
     });
 }
 
-/// Drop the process out of the macOS Dock / Cmd-Tab by switching it to an
-/// accessory app. No-op off macOS.
+/// Keep the process out of the Dock / Cmd-Tab by making it an accessory app.
 ///
-/// Scheduled onto the event loop rather than run inline: winit's
-/// `applicationDidFinishLaunching` forces `.regular` for an unbundled
-/// `cargo run`, and it fires once the loop starts. An inline call during
-/// daemon startup would be clobbered. Running post-launch makes `.accessory`
-/// stick. Packaged `.app` builds reach the same state through
-/// `background-app = true` (`LSUIElement`), which winit leaves untouched.
+/// Deferred onto the event loop because winit resets an unbundled `cargo run`
+/// back to `.regular` in `applicationDidFinishLaunching` once the loop starts;
+/// an inline call would be undone. Bundled `.app`s use `LSUIElement`
+/// (`background-app = true`) instead.
+#[cfg(target_os = "macos")]
 pub(crate) fn hide_from_dock() {
-    #[cfg(target_os = "macos")]
     slint::invoke_from_event_loop(macos::set_accessory_policy).log_debug("macos: schedule hide-from-dock");
 }
 
@@ -470,10 +467,9 @@ mod macos {
 
     use crate::QueryWindow;
 
-    /// Resolve the shared `NSApplication`, or `None` (logged against
-    /// `caller`) when invoked off the main thread. `MainThreadMarker::new()`
-    /// (rather than `new_unchecked()`) makes an off-thread caller fail loudly
-    /// instead of being UB.
+    /// Shared `NSApplication`, or `None` (logged as `caller`) off the main
+    /// thread. `new()` over `new_unchecked()` so an off-thread call fails loud
+    /// instead of risking UB.
     fn ns_app(caller: &str) -> Option<objc2::rc::Retained<NSApplication>> {
         let Some(mtm) = MainThreadMarker::new() else {
             tracing::error!("{caller} called off the main thread");
@@ -514,11 +510,9 @@ mod macos {
         ns_window.makeKeyAndOrderFront(None);
     }
 
-    /// Switch the process to an accessory (agent) app so it never appears in
-    /// the Dock or Cmd-Tab. Accessory apps can still become key and frontmost,
-    /// so [`activate_and_make_key`] keeps landing focus on show.
-    ///
-    /// See [`super::hide_from_dock`] for the post-launch scheduling rationale.
+    /// Accessory app: no Dock icon, no Cmd-Tab entry. Still becomes
+    /// key/frontmost, so [`activate_and_make_key`] is unaffected. Scheduled
+    /// post-launch, see [`super::hide_from_dock`].
     pub fn set_accessory_policy() {
         let Some(app) = ns_app("set_accessory_policy") else {
             return;

--- a/src/window.rs
+++ b/src/window.rs
@@ -190,7 +190,7 @@ pub(crate) fn configure(window: &QueryWindow, settings: SettingsController) {
 ///
 /// Scheduled onto the event loop rather than run inline: winit's
 /// `applicationDidFinishLaunching` forces `.regular` for an unbundled
-/// `cargo run`, and it fires once the loop starts — an inline call during
+/// `cargo run`, and it fires once the loop starts. An inline call during
 /// daemon startup would be clobbered. Running post-launch makes `.accessory`
 /// stick. Packaged `.app` builds reach the same state through
 /// `background-app = true` (`LSUIElement`), which winit leaves untouched.

--- a/src/window.rs
+++ b/src/window.rs
@@ -15,6 +15,8 @@ use slint::winit_030::{EventResult, WinitWindowAccessor, winit};
 use slint::{Image, Rgba8Pixel, SharedPixelBuffer};
 
 use crate::QueryWindow;
+#[cfg(target_os = "macos")]
+use crate::logging::LogErr;
 use crate::settings::WindowPosition;
 use crate::settings_ui::SettingsController;
 use crate::theme::ThemeVariant;
@@ -181,11 +183,20 @@ pub(crate) fn configure(window: &QueryWindow, settings: SettingsController) {
 
         EventResult::Propagate
     });
+}
 
-    // TODO: hide macOS Dock/Cmd-Tab presence via
-    // `NSApp.setActivationPolicy(NSApplicationActivationPolicyAccessory)`, or
-    // bundle as `.app` with `LSUIElement=1` in Info.plist. Independent of the
-    // activation logic below.
+/// Drop the process out of the macOS Dock / Cmd-Tab by switching it to an
+/// accessory app. No-op off macOS.
+///
+/// Scheduled onto the event loop rather than run inline: winit's
+/// `applicationDidFinishLaunching` forces `.regular` for an unbundled
+/// `cargo run`, and it fires once the loop starts — an inline call during
+/// daemon startup would be clobbered. Running post-launch makes `.accessory`
+/// stick. Packaged `.app` builds reach the same state through
+/// `background-app = true` (`LSUIElement`), which winit leaves untouched.
+pub(crate) fn hide_from_dock() {
+    #[cfg(target_os = "macos")]
+    slint::invoke_from_event_loop(macos::set_accessory_policy).log_debug("macos: schedule hide-from-dock");
 }
 
 /// Push theme tokens into the window's `in-out` properties. Re-callable
@@ -451,7 +462,7 @@ mod macos {
 
     use std::ptr::NonNull;
 
-    use objc2_app_kit::{NSApplication, NSView, NSWindow};
+    use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy, NSView, NSWindow};
     use objc2_foundation::MainThreadMarker;
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     use slint::ComponentHandle;
@@ -459,20 +470,30 @@ mod macos {
 
     use crate::QueryWindow;
 
+    /// Resolve the shared `NSApplication`, or `None` (logged against
+    /// `caller`) when invoked off the main thread. `MainThreadMarker::new()`
+    /// (rather than `new_unchecked()`) makes an off-thread caller fail loudly
+    /// instead of being UB.
+    fn ns_app(caller: &str) -> Option<objc2::rc::Retained<NSApplication>> {
+        let Some(mtm) = MainThreadMarker::new() else {
+            tracing::error!("{caller} called off the main thread");
+            return None;
+        };
+
+        Some(NSApplication::sharedApplication(mtm))
+    }
+
     /// Activate our app process and make our `NSWindow` key + frontmost.
     ///
     /// Order matters: `NSApp.activate(ignoringOtherApps: true)` first to
     /// flip the process to frontmost; without it `makeKeyAndOrderFront` on
     /// a background app's window may show the window but won't move keyboard
-    /// focus. `MainThreadMarker::new()` (rather than `new_unchecked()`) makes
-    /// a future off-thread caller fail loudly instead of being UB.
+    /// focus.
     pub fn activate_and_make_key(window: &QueryWindow) {
-        let Some(mtm) = MainThreadMarker::new() else {
-            tracing::error!("activate_and_make_key called off the main thread");
+        let Some(app) = ns_app("activate_and_make_key") else {
             return;
         };
 
-        let app = NSApplication::sharedApplication(mtm);
         // reason: `activateIgnoringOtherApps:` is deprecated in macOS 14 in
         // favour of cooperative `activate()`, but launchers explicitly do NOT
         // want to be cooperative — the whole point is being summoned over
@@ -491,6 +512,21 @@ mod macos {
         };
 
         ns_window.makeKeyAndOrderFront(None);
+    }
+
+    /// Switch the process to an accessory (agent) app so it never appears in
+    /// the Dock or Cmd-Tab. Accessory apps can still become key and frontmost,
+    /// so [`activate_and_make_key`] keeps landing focus on show.
+    ///
+    /// See [`super::hide_from_dock`] for the post-launch scheduling rationale.
+    pub fn set_accessory_policy() {
+        let Some(app) = ns_app("set_accessory_policy") else {
+            return;
+        };
+
+        if !app.setActivationPolicy(NSApplicationActivationPolicy::Accessory) {
+            tracing::warn!("setActivationPolicy(.accessory) was rejected");
+        }
     }
 
     fn ns_window_from_winit(winit_window: &winit::window::Window) -> Option<objc2::rc::Retained<NSWindow>> {


### PR DESCRIPTION
Runs the daemon as an accessory app (`NSApp.setActivationPolicy(.accessory)`) so it no longer shows in the Dock or Cmd-Tab.

Scheduled onto the event loop rather than called inline: winit forces `.regular` for an unbundled `cargo run` in `applicationDidFinishLaunching` and would clobber an early call. Packaged `.app` builds keep relying on `background-app = true` (`LSUIElement`), which winit leaves untouched. Accessory apps still become key/frontmost, so the show/focus path is unaffected.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)