### PR TITLE
feat(db): adopt rusqlite_migration for versioned schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,6 +2166,7 @@ dependencies = [
  "reqwest",
  "rquickjs",
  "rusqlite",
+ "rusqlite_migration",
  "semver",
  "serde",
  "serde_json",
@@ -4760,6 +4761,16 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rusqlite_migration"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923b42e802f7dc20a0a6b5e097ba7c83fe4289da07e49156fecf6af08aa9cd1c"
+dependencies = [
+ "log",
+ "rusqlite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,6 +189,12 @@ open = "5"
 # writes from one thread; a plain `Mutex<Connection>` suffices.
 rusqlite = { version = "0.32", features = ["bundled"] }
 
+# Versioned schema migrations over the same bundled `rusqlite` — a thin
+# `user_version` tracker, no query layer (diesel/sqlx) and no SQL-file
+# embedding (refinery). 1.x is pinned to rusqlite 0.32; 2.x wants 0.40+.
+# Default features off drops the unused tokio + include_dir paths.
+rusqlite_migration = { version = "1.3.1", default-features = false }
+
 # `nucleo-matcher` exposes per-match char indices so we can round-trip
 # highlight ranges to JS.
 nucleo-matcher = "0.3"

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -5,7 +5,7 @@ big choices, threading model, cancellation contract, and the Slint
 gotchas that took a day to debug the first time around. Read this when
 you're about to touch the host, not when you're using it.
 
-For the module layout, `src/lib.rs` is the source of truth — listing
+For the module layout, `src/lib.rs` is the source of truth. Listing
 modules here just drifts on every rename. For the plugin-author API,
 see [plugin-authoring.md](./plugin-authoring.md) and
 [sdk-reference.md](./sdk-reference.md).
@@ -25,14 +25,14 @@ see [plugin-authoring.md](./plugin-authoring.md) and
 Three threads carry the protocol; a handful of small ones do
 fire-and-forget housekeeping.
 
-- **Slint event loop (main)** — owns the window, runs Slint callbacks,
+- **Slint event loop (main)**: owns the window, runs Slint callbacks,
   owns the `global-hotkey` manager on macOS. All Slint operations must
   run here; other threads route through `slint::invoke_from_event_loop`.
-- **`highbeam-plugin-runtime`** — single-threaded tokio runtime that
+- **`highbeam-plugin-runtime`**: single-threaded tokio runtime that
   owns every loaded `LoadedPlugin` (rquickjs `AsyncContext`). Plugins
   live here because rquickjs futures are `!Send` across `async_with!`
   under the `parallel` feature, so they can't cross threads.
-- **`highbeam-ipc`** — blocks on the unix socket; hops back to the
+- **`highbeam-ipc`**: blocks on the unix socket; hops back to the
   Slint thread to show the window.
 
 The hotkey listener thread (`highbeam-hotkey`, macOS only) is a tiny
@@ -52,7 +52,7 @@ write paths.
 - All host APIs that do I/O (`http.get`, `fs.readDir`, `system.exec`,
   etc.) accept an optional `signal` and honor it.
 - CPU-bound plugins that block synchronously can't be cancelled
-  gracefully — the per-plugin `timeoutMs` is the hard kill via the
+  gracefully. The per-plugin `timeoutMs` is the hard kill via the
   rquickjs interrupt hook. The watchdog runs on the blocking thread
   pool so a `while(true){}` JS body can't starve it.
 
@@ -69,21 +69,21 @@ write paths.
 ## Schema migrations
 
 The frecency and query-history schemas are versioned with
-`rusqlite_migration` — a thin layer over the `rusqlite` we already bundle.
+`rusqlite_migration`, a thin layer over the `rusqlite` we already bundle.
 It tracks applied versions in SQLite's `user_version` pragma and replays an
 ordered list of `M::up(...)` statements via `to_latest`. The list lives
 inline in each `db.rs` (the `MIGRATIONS` static), so there are no loose
 `.sql` files and no build step.
 
-Why this over the alternatives the issue raised:
+Why this over the alternatives:
 
-- **`rusqlite_migration`** *(chosen)* — keeps the raw `rusqlite` already in
+- **`rusqlite_migration`** *(chosen)*: keeps the raw `rusqlite` already in
   the tree, adds one small crate (plus `log`), and brings no query layer.
   The 1.x line pins to `rusqlite` 0.32; moving to 2.x would force `rusqlite`
   to 0.40+.
-- **`refinery`** — also rusqlite-compatible, but embeds `.sql` files through
+- **`refinery`**: also rusqlite-compatible, but embeds `.sql` files through
   a proc-macro and carries multi-backend machinery we'd never exercise.
-- **`diesel` / `sqlx` migrations** — arrive welded to an ORM / async query
+- **`diesel` / `sqlx` migrations**: arrive welded to an ORM / async query
   layer. Two single-table databases don't want a query layer, and both add
   meaningful binary size.
 
@@ -98,12 +98,12 @@ Core system actions (shutdown / restart / lock / sleep / exit High Beam
 / install / reload / update / settings / version readout) are
 implemented in Rust as in-process built-ins
 (`src/plugins/builtin/core.rs`). They appear alongside JS plugins in
-the result list but never go through rquickjs — a buggy plugin must
+the result list but never go through rquickjs. A buggy plugin must
 not be able to power off the user's machine.
 
 ## Slint gotchas
 
-These are load-bearing for future UI work — they're easy to relearn
+These are load-bearing for future UI work; they're easy to relearn
 the hard way.
 
 ### Daemon-shaped event loops: do NOT use `ComponentHandle::run()`
@@ -111,7 +111,7 @@ the hard way.
 `ComponentHandle::run()` calls `show()` → `run_event_loop()` →
 `hide()` and couples the event-loop lifetime to the window's
 lifetime. The first time the last window closes, the loop ends and
-the daemon dies — taking the IPC listener and global hotkey with it.
+the daemon dies, taking the IPC listener and global hotkey with it.
 
 Use `slint::run_event_loop_until_quit()`. Show/hide windows freely;
 the loop only ends on explicit `quit_event_loop()`.
@@ -139,7 +139,7 @@ that directly assigns `input.text = ""` and call it from Rust.
 Slint 1.16's Wayland `hide()` destroys the underlying winit window
 via `suspend()`, and when the destroy fails (because Slint's renderer
 holds extra `Arc<winit::Window>` refs we can't drop from app code)
-the state still flips to `None` — so the *next* `show()` won't
+the state still flips to `None`, so the *next* `show()` won't
 re-attach the surface and the launcher silently never opens again.
 
 The workaround in `src/window.rs::hide`: set an `is-hidden` flag in
@@ -170,7 +170,7 @@ In `src/window.rs` (gated `#[cfg(target_os = "macos")]`):
 
 1. `NSApplication.sharedApplication().activate(ignoringOtherApps: true)`
 2. `nsWindow.makeKeyAndOrderFront(nil)`
-3. Slint's focus call — now sticks.
+3. Slint's focus call (now sticks).
 
 `activateIgnoringOtherApps:` is deprecated on macOS 14+ in favor of
 cooperative `activate()`. Launchers explicitly want non-cooperative
@@ -199,7 +199,7 @@ Considered seriously. Rejected because:
 
 - Async + debugging DX are still rough in WASI Preview 2 / Component
   Model.
-- Sandboxing is theoretical — Alfred (900+ workflows), Raycast (2000+
+- Sandboxing is theoretical: Alfred (900+ workflows), Raycast (2000+
   extensions), Albert, Ulauncher all forgo it. Without sandboxing as
   a load-bearing reason, the DX cost is too high.
 - Polyglot plugins are a feature we don't need.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -17,7 +17,7 @@ see [plugin-authoring.md](./plugin-authoring.md) and
 | Language | Rust (edition 2024) | Native binary, no GC, mature ecosystem for the pieces we need |
 | UI toolkit | Slint | Declarative `.slint` files with runtime-bound properties (good fit for theme tokens); winit windowing |
 | Plugin runtime | rquickjs (QuickJS binding) | ~1 MB embed, pure ECMAScript (not Node), per-context memory caps, interrupt hooks for timeouts |
-| Persistence | SQLite via `rusqlite` | Frecency + query history. Boring, reliable. |
+| Persistence | SQLite via `rusqlite` | Frecency + query history; schemas versioned with `rusqlite_migration`. Boring, reliable. |
 | Global hotkey | `global-hotkey` (macOS); CLI `--open` (Linux) | Wayland has no portable global-hotkey API; punt to the WM. |
 
 ## Threading
@@ -65,6 +65,32 @@ write paths.
 - Modifier (`src/frecency/score.rs`):
   `1.0 + 0.10 * picks * 2^(-age/14d)`. Half-life 14 days; one fresh
   pick is roughly a 10% bump; modifier decays back to 1.0 as picks age.
+
+## Schema migrations
+
+The frecency and query-history schemas are versioned with
+`rusqlite_migration` — a thin layer over the `rusqlite` we already bundle.
+It tracks applied versions in SQLite's `user_version` pragma and replays an
+ordered list of `M::up(...)` statements via `to_latest`. The list lives
+inline in each `db.rs` (the `MIGRATIONS` static), so there are no loose
+`.sql` files and no build step.
+
+Why this over the alternatives the issue raised:
+
+- **`rusqlite_migration`** *(chosen)* — keeps the raw `rusqlite` already in
+  the tree, adds one small crate (plus `log`), and brings no query layer.
+  The 1.x line pins to `rusqlite` 0.32; moving to 2.x would force `rusqlite`
+  to 0.40+.
+- **`refinery`** — also rusqlite-compatible, but embeds `.sql` files through
+  a proc-macro and carries multi-backend machinery we'd never exercise.
+- **`diesel` / `sqlx` migrations** — arrive welded to an ORM / async query
+  layer. Two single-table databases don't want a query layer, and both add
+  meaningful binary size.
+
+Migration v1 is the original `CREATE TABLE IF NOT EXISTS`, verbatim: a
+database written before migrations existed already holds its table at
+`user_version` 0, so v1 must no-op against it while still creating the table
+on a fresh file.
 
 ## Built-in plugins live in the host
 

--- a/src/frecency/db.rs
+++ b/src/frecency/db.rs
@@ -63,7 +63,7 @@ impl FrecencyDb {
             )
         })?;
         let mut conn = Connection::open(path)?;
-        MIGRATIONS.to_latest(&mut conn).map_err(|err| migration_failed(&err))?;
+        MIGRATIONS.to_latest(&mut conn).map_err(migration_failed)?;
         Ok(Self {
             inner: Arc::new(Mutex::new(conn)),
         })
@@ -77,7 +77,7 @@ impl FrecencyDb {
     #[cfg(test)]
     pub(crate) fn open_in_memory() -> rusqlite::Result<Self> {
         let mut conn = Connection::open_in_memory()?;
-        MIGRATIONS.to_latest(&mut conn).map_err(|err| migration_failed(&err))?;
+        MIGRATIONS.to_latest(&mut conn).map_err(migration_failed)?;
         Ok(Self {
             inner: Arc::new(Mutex::new(conn)),
         })
@@ -184,7 +184,7 @@ impl FrecencyDb {
 
 /// Fold a migration failure into `rusqlite`'s error type so `open` keeps a
 /// single `rusqlite::Result` surface for its caller.
-fn migration_failed(err: &rusqlite_migration::Error) -> rusqlite::Error {
+fn migration_failed(err: rusqlite_migration::Error) -> rusqlite::Error {
     rusqlite::Error::SqliteFailure(
         rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),
         Some(format!("frecency schema migration failed: {err}")),

--- a/src/frecency/db.rs
+++ b/src/frecency/db.rs
@@ -63,7 +63,7 @@ impl FrecencyDb {
             )
         })?;
         let mut conn = Connection::open(path)?;
-        MIGRATIONS.to_latest(&mut conn).map_err(migration_failed)?;
+        MIGRATIONS.to_latest(&mut conn).map_err(|err| migration_failed(&err))?;
         Ok(Self {
             inner: Arc::new(Mutex::new(conn)),
         })
@@ -77,7 +77,7 @@ impl FrecencyDb {
     #[cfg(test)]
     pub(crate) fn open_in_memory() -> rusqlite::Result<Self> {
         let mut conn = Connection::open_in_memory()?;
-        MIGRATIONS.to_latest(&mut conn).map_err(migration_failed)?;
+        MIGRATIONS.to_latest(&mut conn).map_err(|err| migration_failed(&err))?;
         Ok(Self {
             inner: Arc::new(Mutex::new(conn)),
         })
@@ -184,7 +184,7 @@ impl FrecencyDb {
 
 /// Fold a migration failure into `rusqlite`'s error type so `open` keeps a
 /// single `rusqlite::Result` surface for its caller.
-fn migration_failed(err: rusqlite_migration::Error) -> rusqlite::Error {
+fn migration_failed(err: &rusqlite_migration::Error) -> rusqlite::Error {
     rusqlite::Error::SqliteFailure(
         rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),
         Some(format!("frecency schema migration failed: {err}")),

--- a/src/frecency/db.rs
+++ b/src/frecency/db.rs
@@ -1,31 +1,37 @@
 //! `SQLite` storage for the `picks` frecency table.
 //!
-//! `CREATE TABLE IF NOT EXISTS` is the whole migration system — no history
-//! to evolve yet. TODO: switch to `rusqlite_migration` the first time the
-//! schema actually changes.
+//! The schema is versioned through `rusqlite_migration`: [`MIGRATIONS`] is the
+//! ordered list and `to_latest` brings any opened connection up to the newest.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(test)]
 use rusqlite::OptionalExtension;
 use rusqlite::{Connection, params};
+use rusqlite_migration::{M, Migrations};
 
 use crate::paths::ensure_parent_dir;
 
 // Composite PRIMARY KEY generates an implicit unique index used for both
 // lookups and upserts — no additional index needed.
-const SCHEMA_SQL: &str = "\
-CREATE TABLE IF NOT EXISTS picks (
+//
+// v1 keeps `IF NOT EXISTS`: databases written before migrations existed
+// already hold this table at `user_version` 0, so v1 must no-op against them
+// while still creating the table on a fresh file.
+static MIGRATIONS: LazyLock<Migrations<'static>> = LazyLock::new(|| {
+    Migrations::new(vec![M::up(
+        "CREATE TABLE IF NOT EXISTS picks (
     plugin_name      TEXT    NOT NULL,
     result_key       TEXT    NOT NULL,
     picks            INTEGER NOT NULL DEFAULT 1,
     last_picked_at   INTEGER NOT NULL,
     PRIMARY KEY (plugin_name, result_key)
-);
-";
+);",
+    )])
+});
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PickRow {
@@ -56,8 +62,8 @@ impl FrecencyDb {
                 Some(format!("create parent dir for {}: {err}", path.display())),
             )
         })?;
-        let conn = Connection::open(path)?;
-        conn.execute_batch(SCHEMA_SQL)?;
+        let mut conn = Connection::open(path)?;
+        MIGRATIONS.to_latest(&mut conn).map_err(|err| migration_failed(&err))?;
         Ok(Self {
             inner: Arc::new(Mutex::new(conn)),
         })
@@ -70,8 +76,8 @@ impl FrecencyDb {
     /// Returns the same SQL error set as [`Self::open`].
     #[cfg(test)]
     pub(crate) fn open_in_memory() -> rusqlite::Result<Self> {
-        let conn = Connection::open_in_memory()?;
-        conn.execute_batch(SCHEMA_SQL)?;
+        let mut conn = Connection::open_in_memory()?;
+        MIGRATIONS.to_latest(&mut conn).map_err(|err| migration_failed(&err))?;
         Ok(Self {
             inner: Arc::new(Mutex::new(conn)),
         })
@@ -176,6 +182,15 @@ impl FrecencyDb {
     }
 }
 
+/// Fold a migration failure into `rusqlite`'s error type so `open` keeps a
+/// single `rusqlite::Result` surface for its caller.
+fn migration_failed(err: &rusqlite_migration::Error) -> rusqlite::Error {
+    rusqlite::Error::SqliteFailure(
+        rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),
+        Some(format!("frecency schema migration failed: {err}")),
+    )
+}
+
 /// Wall-clock seconds since Unix epoch. Saturates to 0 on pre-epoch clocks
 /// rather than panicking.
 #[must_use]
@@ -225,6 +240,43 @@ pub(crate) fn default_db_path() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn migrations_are_valid() {
+        MIGRATIONS.validate().expect("migration set is well-formed");
+    }
+
+    #[test]
+    fn migrates_legacy_db_left_at_version_zero() {
+        // Reproduce a database written before migrations existed: the table is
+        // already present and `user_version` is still 0. v1 must adopt it
+        // without error and without dropping rows.
+        let mut conn = Connection::open_in_memory().expect("open");
+        conn.execute_batch(
+            "CREATE TABLE picks (
+                plugin_name    TEXT    NOT NULL,
+                result_key     TEXT    NOT NULL,
+                picks          INTEGER NOT NULL DEFAULT 1,
+                last_picked_at INTEGER NOT NULL,
+                PRIMARY KEY (plugin_name, result_key)
+            );
+            INSERT INTO picks VALUES ('demo', 'alpha', 3, 1700000000);",
+        )
+        .expect("seed legacy schema");
+
+        MIGRATIONS.to_latest(&mut conn).expect("adopt legacy db");
+
+        let version: i64 = conn
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .expect("user_version");
+        let picks: u32 = conn
+            .query_row("SELECT picks FROM picks WHERE plugin_name = 'demo'", [], |row| {
+                row.get(0)
+            })
+            .expect("legacy row survives");
+        assert_eq!(version, 1);
+        assert_eq!(picks, 3);
+    }
 
     #[test]
     fn open_in_memory_creates_schema() {

--- a/src/query_history/db.rs
+++ b/src/query_history/db.rs
@@ -49,7 +49,7 @@ impl QueryHistoryDb {
             )
         })?;
         let mut conn = Connection::open(path)?;
-        MIGRATIONS.to_latest(&mut conn).map_err(migration_failed)?;
+        MIGRATIONS.to_latest(&mut conn).map_err(|err| migration_failed(&err))?;
         Ok(Self {
             inner: Arc::new(Mutex::new(conn)),
         })
@@ -63,7 +63,7 @@ impl QueryHistoryDb {
     #[cfg(test)]
     pub(crate) fn open_in_memory() -> rusqlite::Result<Self> {
         let mut conn = Connection::open_in_memory()?;
-        MIGRATIONS.to_latest(&mut conn).map_err(migration_failed)?;
+        MIGRATIONS.to_latest(&mut conn).map_err(|err| migration_failed(&err))?;
         Ok(Self {
             inner: Arc::new(Mutex::new(conn)),
         })
@@ -144,7 +144,7 @@ impl QueryHistoryDb {
 
 /// Fold a migration failure into `rusqlite`'s error type so `open` keeps a
 /// single `rusqlite::Result` surface for its caller.
-fn migration_failed(err: rusqlite_migration::Error) -> rusqlite::Error {
+fn migration_failed(err: &rusqlite_migration::Error) -> rusqlite::Error {
     rusqlite::Error::SqliteFailure(
         rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),
         Some(format!("query_history schema migration failed: {err}")),

--- a/src/query_history/db.rs
+++ b/src/query_history/db.rs
@@ -49,7 +49,7 @@ impl QueryHistoryDb {
             )
         })?;
         let mut conn = Connection::open(path)?;
-        MIGRATIONS.to_latest(&mut conn).map_err(|err| migration_failed(&err))?;
+        MIGRATIONS.to_latest(&mut conn).map_err(migration_failed)?;
         Ok(Self {
             inner: Arc::new(Mutex::new(conn)),
         })
@@ -63,7 +63,7 @@ impl QueryHistoryDb {
     #[cfg(test)]
     pub(crate) fn open_in_memory() -> rusqlite::Result<Self> {
         let mut conn = Connection::open_in_memory()?;
-        MIGRATIONS.to_latest(&mut conn).map_err(|err| migration_failed(&err))?;
+        MIGRATIONS.to_latest(&mut conn).map_err(migration_failed)?;
         Ok(Self {
             inner: Arc::new(Mutex::new(conn)),
         })
@@ -144,7 +144,7 @@ impl QueryHistoryDb {
 
 /// Fold a migration failure into `rusqlite`'s error type so `open` keeps a
 /// single `rusqlite::Result` surface for its caller.
-fn migration_failed(err: &rusqlite_migration::Error) -> rusqlite::Error {
+fn migration_failed(err: rusqlite_migration::Error) -> rusqlite::Error {
     rusqlite::Error::SqliteFailure(
         rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),
         Some(format!("query_history schema migration failed: {err}")),

--- a/src/query_history/db.rs
+++ b/src/query_history/db.rs
@@ -5,20 +5,26 @@
 //! secondary index. `created_at` is informational only.
 
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use rusqlite::{Connection, params};
+use rusqlite_migration::{M, Migrations};
 
 use crate::frecency::now_seconds;
 use crate::paths::ensure_parent_dir;
 
-const SCHEMA_SQL: &str = "\
-CREATE TABLE IF NOT EXISTS query_history (
+// v1 keeps `IF NOT EXISTS`: databases written before migrations existed
+// already hold this table at `user_version` 0, so v1 must no-op against them
+// while still creating the table on a fresh file.
+static MIGRATIONS: LazyLock<Migrations<'static>> = LazyLock::new(|| {
+    Migrations::new(vec![M::up(
+        "CREATE TABLE IF NOT EXISTS query_history (
     id         INTEGER PRIMARY KEY AUTOINCREMENT,
     query      TEXT    NOT NULL,
     created_at INTEGER NOT NULL
-);
-";
+);",
+    )])
+});
 
 /// Owned handle to the query-history database. `Arc<Mutex>` matches the
 /// frecency-db pattern: single-threaded access, uncontended on the hot path.
@@ -42,8 +48,8 @@ impl QueryHistoryDb {
                 Some(format!("create parent dir for {}: {err}", path.display())),
             )
         })?;
-        let conn = Connection::open(path)?;
-        conn.execute_batch(SCHEMA_SQL)?;
+        let mut conn = Connection::open(path)?;
+        MIGRATIONS.to_latest(&mut conn).map_err(|err| migration_failed(&err))?;
         Ok(Self {
             inner: Arc::new(Mutex::new(conn)),
         })
@@ -56,8 +62,8 @@ impl QueryHistoryDb {
     /// Returns the same SQL error set as [`Self::open`].
     #[cfg(test)]
     pub(crate) fn open_in_memory() -> rusqlite::Result<Self> {
-        let conn = Connection::open_in_memory()?;
-        conn.execute_batch(SCHEMA_SQL)?;
+        let mut conn = Connection::open_in_memory()?;
+        MIGRATIONS.to_latest(&mut conn).map_err(|err| migration_failed(&err))?;
         Ok(Self {
             inner: Arc::new(Mutex::new(conn)),
         })
@@ -136,6 +142,15 @@ impl QueryHistoryDb {
     }
 }
 
+/// Fold a migration failure into `rusqlite`'s error type so `open` keeps a
+/// single `rusqlite::Result` surface for its caller.
+fn migration_failed(err: &rusqlite_migration::Error) -> rusqlite::Error {
+    rusqlite::Error::SqliteFailure(
+        rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),
+        Some(format!("query_history schema migration failed: {err}")),
+    )
+}
+
 /// Resolve the on-disk path for the query-history DB. Returns `None` if
 /// the platform data directory can't be resolved.
 #[must_use]
@@ -146,6 +161,39 @@ pub(crate) fn default_db_path() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn migrations_are_valid() {
+        MIGRATIONS.validate().expect("migration set is well-formed");
+    }
+
+    #[test]
+    fn migrates_legacy_db_left_at_version_zero() {
+        // Reproduce a database written before migrations existed: the table is
+        // already present and `user_version` is still 0. v1 must adopt it
+        // without error and without dropping rows.
+        let mut conn = Connection::open_in_memory().expect("open");
+        conn.execute_batch(
+            "CREATE TABLE query_history (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                query      TEXT    NOT NULL,
+                created_at INTEGER NOT NULL
+            );
+            INSERT INTO query_history (query, created_at) VALUES ('legacy', 1700000000);",
+        )
+        .expect("seed legacy schema");
+
+        MIGRATIONS.to_latest(&mut conn).expect("adopt legacy db");
+
+        let version: i64 = conn
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .expect("user_version");
+        let query: String = conn
+            .query_row("SELECT query FROM query_history LIMIT 1", [], |row| row.get(0))
+            .expect("legacy row survives");
+        assert_eq!(version, 1);
+        assert_eq!(query, "legacy");
+    }
 
     #[test]
     fn open_in_memory_creates_schema() {


### PR DESCRIPTION
Adopts `rusqlite_migration` over the already-bundled `rusqlite` to version the frecency and query-history schemas, replacing ad-hoc `CREATE TABLE IF NOT EXISTS` with versioned migrations.

**Framework choice**
- **`rusqlite_migration`** (chosen): thin `user_version` tracker on the `rusqlite` we already ship. No query layer, no SQL-file embedding. One small crate (plus `log`). 1.x pins to rusqlite 0.32.
- **`refinery`**: rusqlite-compatible, but embeds `.sql` via proc-macro and carries multi-backend machinery we'd never use.
- **`diesel` / `sqlx`**: bundle an ORM / async query layer. Two single-table DBs don't want one, and both add binary size.

Migration v1 keeps `IF NOT EXISTS` so databases written before migrations existed (table present, `user_version` 0) adopt cleanly without dropping rows. A legacy-DB test in each module covers this. Full rationale in `docs/internals.md`.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)