### PR TITLE
fix: startup crash-safety — theme fallback test + lock poison recovery

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5,7 +5,7 @@
 use std::error::Error;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, PoisonError, RwLock};
 use std::thread;
 
 use slint::ComponentHandle;
@@ -50,12 +50,6 @@ pub struct Options {
 /// Returns an error if the Slint backend fails to initialize, the window
 /// fails to construct, the unix socket can't be bound (e.g. another daemon
 /// is already running), or the event loop reports a runtime error.
-///
-/// # Panics
-///
-/// Panics if the active-theme `RwLock` is poisoned — a previous panic while
-/// holding it corrupted the shared theme and painting from it would risk
-/// rendering garbage.
 // reason: `Options` is a config struct created by the caller and consumed
 // here; by-value is more ergonomic than forcing the caller to keep it alive.
 #[allow(clippy::needless_pass_by_value)]
@@ -97,7 +91,7 @@ pub fn run(options: Options) -> Result<(), Box<dyn Error>> {
     // with the appearance watcher via `Arc`.
     let theme = Arc::new(RwLock::new(Theme::load_named(settings_for_ui.theme())));
     {
-        let theme = theme.read().expect("theme lock");
+        let theme = theme.read().unwrap_or_else(PoisonError::into_inner);
         window::apply_theme(
             &window,
             theme.variant_for(settings_for_ui.theme_mode(), os_appearance::current()),
@@ -118,7 +112,7 @@ pub fn run(options: Options) -> Result<(), Box<dyn Error>> {
             let mode = controller.theme_mode();
             slint::invoke_from_event_loop(move || {
                 if let Some(w) = weak.upgrade() {
-                    let theme = theme.read().expect("theme lock");
+                    let theme = theme.read().unwrap_or_else(PoisonError::into_inner);
                     window::apply_theme(&w, theme.variant_for(mode, appearance));
                 }
             })

--- a/src/settings_ui.rs
+++ b/src/settings_ui.rs
@@ -8,7 +8,7 @@
 //! state is independent of the query/results state.
 
 use std::sync::mpsc;
-use std::sync::{Arc, Mutex, OnceLock, RwLock, Weak};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock, PoisonError, RwLock, Weak};
 use std::thread;
 
 use serde_json::Value as JsonValue;
@@ -70,6 +70,17 @@ struct Inner {
     /// Mutators send `()` here; the writer thread drains the queue and
     /// flushes once per burst.
     dirty_tx: mpsc::Sender<()>,
+}
+
+impl Inner {
+    /// Lock the settings mutex, recovering the guard if a previous holder
+    /// panicked. Poisoning only happens on a panic mid-write, which this
+    /// otherwise panic-free path shouldn't hit — but recovering the (plain,
+    /// still-structurally-valid) `Settings` beats taking the daemon down
+    /// mid-interaction over a lock we can simply re-acquire.
+    fn lock_settings(&self) -> MutexGuard<'_, Settings> {
+        self.settings.lock().unwrap_or_else(PoisonError::into_inner)
+    }
 }
 
 impl SettingsController {
@@ -254,7 +265,7 @@ impl SettingsController {
         // Theme dropdown is refreshed separately (`refresh_themes`) to keep its
         // disk scan off every global mutation.
         let (hotkey, alt_mod, theme_mode) = {
-            let settings = self.inner.settings.lock().expect("settings lock");
+            let settings = self.inner.lock_settings();
             (
                 settings.global().hotkey.clone(),
                 settings.alt_action_modifier().to_owned(),
@@ -294,7 +305,7 @@ impl SettingsController {
 
     fn set_hotkey(&self, value: &str) {
         {
-            let mut settings = self.inner.settings.lock().expect("settings lock");
+            let mut settings = self.inner.lock_settings();
             settings.set_hotkey(value);
         }
 
@@ -303,7 +314,7 @@ impl SettingsController {
 
     fn set_alt_action_modifier(&self, value: &str) {
         {
-            let mut settings = self.inner.settings.lock().expect("settings lock");
+            let mut settings = self.inner.lock_settings();
             settings.set_alt_action_modifier(value);
         }
 
@@ -356,31 +367,22 @@ impl SettingsController {
     /// Replace the shared active theme with the user's current selection,
     /// re-read from disk. Used by both the selector (after the settings write)
     /// and the reload button.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the theme lock is poisoned — a previous panic while holding
-    /// it corrupted the shared state and continuing risks painting garbage.
     fn swap_active_theme(&self, theme: &Arc<RwLock<Theme>>) {
         let loaded = Theme::load_named(&self.theme());
-        *theme.write().expect("theme lock") = loaded;
+        *theme.write().unwrap_or_else(PoisonError::into_inner) = loaded;
     }
 
     /// Paint the active theme's variant for `mode` against the current system
     /// appearance. Reads the shared theme under a read lock; the borrow can't
     /// escape the guard, so the apply happens inside the locked scope.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the theme lock is poisoned. See [`Self::swap_active_theme`].
     fn apply_active_theme(window: &QueryWindow, theme: &Arc<RwLock<Theme>>, mode: ThemeMode) {
-        let guard = theme.read().expect("theme lock");
+        let guard = theme.read().unwrap_or_else(PoisonError::into_inner);
         window::apply_theme(window, guard.variant_for(mode, os_appearance::current()));
     }
 
     fn set_theme_mode(&self, value: &str) {
         {
-            let mut settings = self.inner.settings.lock().expect("settings lock");
+            let mut settings = self.inner.lock_settings();
             settings.set_theme_mode(value);
         }
 
@@ -389,7 +391,7 @@ impl SettingsController {
 
     fn set_theme(&self, value: &str) {
         {
-            let mut settings = self.inner.settings.lock().expect("settings lock");
+            let mut settings = self.inner.lock_settings();
             settings.set_theme(value);
         }
 
@@ -398,26 +400,15 @@ impl SettingsController {
 
     /// The user's currently selected theme name (file stem or the reserved
     /// default). Read when swapping / reloading the active theme.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the settings mutex is poisoned. See
-    /// [`Self::launcher_position`] for the rationale.
     fn theme(&self) -> String {
-        self.inner.settings.lock().expect("settings lock").theme().to_owned()
+        self.inner.lock_settings().theme().to_owned()
     }
 
     /// Last saved launcher window origin, or `None` if the user has never
     /// dragged the window (or just cleared it via Recenter).
-    ///
-    /// # Panics
-    ///
-    /// Panics if the settings mutex is poisoned — a previous panic while
-    /// holding the lock corrupted the shared state and continuing risks
-    /// writing the corruption to disk.
     #[must_use]
     pub fn launcher_position(&self) -> Option<WindowPosition> {
-        let settings = self.inner.settings.lock().expect("settings lock");
+        let settings = self.inner.lock_settings();
         settings.global().launcher_position
     }
 
@@ -429,14 +420,9 @@ impl SettingsController {
     ///
     /// Resolves the platform-specific Slint Cmd↔Ctrl swap (the same one
     /// the hotkey formatter has to handle).
-    ///
-    /// # Panics
-    ///
-    /// Panics if the settings mutex is poisoned. See
-    /// [`Self::launcher_position`] for the rationale.
     #[must_use]
     pub fn alt_modifier_held(&self, mods: u8) -> bool {
-        let settings = self.inner.settings.lock().expect("settings lock");
+        let settings = self.inner.lock_settings();
 
         match settings.alt_action_modifier() {
             "Alt" => mods & MOD_ALT != 0,
@@ -469,14 +455,9 @@ impl SettingsController {
 
     /// Current `query_history.max_entries` setting. Read on every history
     /// push so the cap takes effect without a daemon restart.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the settings mutex is poisoned. See
-    /// [`Self::launcher_position`] for the rationale.
     #[must_use]
     pub fn query_history_max_entries(&self) -> usize {
-        let settings = self.inner.settings.lock().expect("settings lock");
+        let settings = self.inner.lock_settings();
         settings.query_history_max_entries()
     }
 
@@ -484,27 +465,17 @@ impl SettingsController {
     /// plugin loader, dispatcher). Persist via the controller's own
     /// `set_*` / `record_loaded_versions` methods rather than mutating the
     /// snapshot — modifications to the returned `Settings` are discarded.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the settings mutex is poisoned. See
-    /// [`Self::launcher_position`] for the rationale.
     #[must_use]
     pub fn snapshot(&self) -> Settings {
-        self.inner.settings.lock().expect("settings lock").clone()
+        self.inner.lock_settings().clone()
     }
 
     /// Current `theme_mode` setting. Read by the OS-appearance watcher on
     /// every tick so toggling between `Auto` / `Dark` / `Light` in a
     /// future settings-UI surface takes effect without a daemon restart.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the settings mutex is poisoned. See
-    /// [`Self::launcher_position`] for the rationale.
     #[must_use]
     pub fn theme_mode(&self) -> ThemeMode {
-        self.inner.settings.lock().expect("settings lock").theme_mode()
+        self.inner.lock_settings().theme_mode()
     }
 
     /// Record the manifest version each `(plugin, Some(version))` pair was
@@ -512,18 +483,13 @@ impl SettingsController {
     /// this so a crash mid-hook can't replay the work on the next boot.
     /// Empty input is a no-op. A `version` of `None` clears the slot
     /// (e.g. on uninstall).
-    ///
-    /// # Panics
-    ///
-    /// Panics if the settings mutex is poisoned. See
-    /// [`Self::launcher_position`] for the rationale.
     pub fn record_loaded_versions(&self, entries: &[(String, Option<String>)]) {
         if entries.is_empty() {
             return;
         }
 
         {
-            let mut s = self.inner.settings.lock().expect("settings lock");
+            let mut s = self.inner.lock_settings();
 
             for (name, version) in entries {
                 s.set_last_loaded_version(name, version.clone());
@@ -534,14 +500,9 @@ impl SettingsController {
     }
 
     /// Record a new launcher window origin and queue a disk flush.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the settings mutex is poisoned. See
-    /// [`Self::launcher_position`] for the rationale.
     pub fn set_launcher_position(&self, position: WindowPosition) {
         {
-            let mut settings = self.inner.settings.lock().expect("settings lock");
+            let mut settings = self.inner.lock_settings();
             settings.set_launcher_position(position);
         }
 
@@ -550,14 +511,9 @@ impl SettingsController {
 
     /// Forget the saved launcher position. The next show recenters via the
     /// existing focused-display math.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the settings mutex is poisoned. See
-    /// [`Self::launcher_position`] for the rationale.
     pub fn clear_launcher_position(&self) {
         {
-            let mut settings = self.inner.settings.lock().expect("settings lock");
+            let mut settings = self.inner.lock_settings();
             settings.clear_launcher_position();
         }
 
@@ -565,7 +521,7 @@ impl SettingsController {
     }
 
     fn refresh_slots(&self, window: &QueryWindow) {
-        let settings = self.inner.settings.lock().expect("settings lock");
+        let settings = self.inner.lock_settings();
         let slots: Vec<PluginSlot> = self
             .inner
             .manifests
@@ -601,7 +557,7 @@ impl SettingsController {
         window.set_selected_plugin_description(SharedString::from(meta.description.as_deref().unwrap_or_default()));
 
         let defs = &manifest.parsed_options().defs;
-        let settings = self.inner.settings.lock().expect("settings lock");
+        let settings = self.inner.lock_settings();
         let user_opts = settings.plugin_options(&manifest.name);
         let options: Vec<PluginOption> = defs
             .iter()
@@ -613,7 +569,7 @@ impl SettingsController {
 
     fn set_enabled(&self, plugin: &str, enabled: bool) {
         {
-            let mut settings = self.inner.settings.lock().expect("settings lock");
+            let mut settings = self.inner.lock_settings();
             settings.set_plugin_enabled(plugin, enabled);
         }
 
@@ -622,7 +578,7 @@ impl SettingsController {
 
     fn set_option(&self, plugin: &str, key: &str, value: JsonValue) {
         {
-            let mut settings = self.inner.settings.lock().expect("settings lock");
+            let mut settings = self.inner.lock_settings();
             settings.set_plugin_option(plugin, key, value);
         }
 
@@ -663,7 +619,7 @@ impl SettingsController {
             // choices; we pick the next one after the current value.
             OptionKind::Enum { default, choices } => {
                 let current = {
-                    let settings = self.inner.settings.lock().expect("settings lock");
+                    let settings = self.inner.lock_settings();
                     settings
                         .plugin_options(plugin)
                         .get(key)
@@ -691,13 +647,8 @@ impl SettingsController {
 
     /// Synchronously save settings to disk, bypassing the writer thread.
     /// For tests that assert on-disk state right after a mutation.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the settings mutex is poisoned. See
-    /// [`Self::launcher_position`] for the rationale.
     pub fn flush(&self) {
-        let settings = self.inner.settings.lock().expect("settings lock");
+        let settings = self.inner.lock_settings();
         settings.save().log_warn("settings: flush failed");
     }
 }
@@ -715,13 +666,7 @@ fn spawn_writer_thread(weak_inner: Weak<Inner>, rx: mpsc::Receiver<()>) {
                 let Some(inner) = weak_inner.upgrade() else {
                     break;
                 };
-                let snapshot = match inner.settings.lock() {
-                    Ok(g) => g.clone(),
-                    Err(err) => {
-                        tracing::error!(?err, "settings: writer saw poisoned lock");
-                        break;
-                    }
-                };
+                let snapshot = inner.lock_settings().clone();
                 drop(inner);
                 snapshot.save().log_warn("settings: writer save failed");
             }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -199,11 +199,22 @@ impl Theme {
             return Self::default_bundled();
         }
 
-        let Some(path) = paths::themes_dir().map(|dir| dir.join(format!("{name}.toml"))) else {
+        let Some(dir) = paths::themes_dir() else {
             tracing::warn!(theme = name, "theme: could not resolve themes dir; using default");
 
             return Self::default_bundled();
         };
+
+        Self::load_named_in(&dir, name)
+    }
+
+    /// Read `<dir>/<name>.toml`, falling back to the bundled default on any
+    /// read or parse error. Split from [`Self::load_named`] so the on-disk
+    /// path is testable against a fixture dir; production resolves `dir` via
+    /// [`paths::themes_dir`]. A malformed file must never abort startup.
+    #[must_use]
+    fn load_named_in(dir: &std::path::Path, name: &str) -> Self {
+        let path = dir.join(format!("{name}.toml"));
 
         match fs::read_to_string(&path) {
             Ok(text) => Self::from_toml_or_default(&text, &path),
@@ -508,7 +519,18 @@ fn expand_nibble(byte: u8) -> Option<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
+
+    /// Per-test scratch directory, unique across parallel tests (distinct
+    /// `tag`) and across runs (clock nanos).
+    fn unique_temp_dir(tag: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock after epoch")
+            .as_nanos();
+
+        std::env::temp_dir().join(format!("high-beam-{tag}-{nanos}"))
+    }
 
     #[test]
     fn default_dark_variant_differs_from_light() {
@@ -760,6 +782,38 @@ mod tests {
         // degrade to the builtin rather than panic or block startup.
         let theme = Theme::load_named("definitely-not-a-real-theme-xyz-9999");
         assert_eq!(theme, Theme::default_bundled());
+    }
+
+    #[test]
+    fn load_named_in_reads_a_valid_file_from_disk() {
+        // Guards the meaning of the corrupt-file test below: prove the on-disk
+        // path actually parses a present file, so a fallback-to-default there
+        // reflects the parse error rather than an always-default no-op.
+        let dir = unique_temp_dir("theme-valid");
+        std::fs::create_dir_all(&dir).expect("create fixture dir");
+        std::fs::write(dir.join("custom.toml"), "[colors]\nbackground = \"#abcdef\"\n").expect("write fixture");
+
+        let theme = Theme::load_named_in(&dir, "custom");
+        assert_eq!(
+            theme.light.colors.background,
+            Color::from_argb_u8(0xFF, 0xAB, 0xCD, 0xEF)
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_named_in_corrupt_file_falls_back_to_default() {
+        // A malformed theme file present on disk must degrade to the bundled
+        // default, never abort startup — the daemon loads the selected theme
+        // at boot, so one bad file would otherwise be a launch blocker.
+        let dir = unique_temp_dir("theme-corrupt");
+        std::fs::create_dir_all(&dir).expect("create fixture dir");
+        std::fs::write(dir.join("broken.toml"), "this = is not [valid toml").expect("write corrupt fixture");
+
+        assert_eq!(Theme::load_named_in(&dir, "broken"), Theme::default_bundled());
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
Closes #33.

Startup was already crash-safe for malformed themes: `Theme::load_named` runs `from_toml_or_default`, which logs and uses the bundled default. The panics the issue cited are a `#[cfg(test)]` CI guard (`theme.rs:789`) and programmer-error guards on our own bundled hex constants (`132`/`152`). A user-dropped file can't reach either, so they're left as-is; both correctly surface a bug in shipped code.

- **Theme**: extracted a dir-injectable `load_named_in` so the on-disk read+parse+fallback is testable, and added a regression test with a corrupt theme file present (plus a valid-file test guarding its meaning).
- **Locks**: replaced `.expect()` on the settings `Mutex` (20 sites) and the active-theme `RwLock` (4 sites) with `PoisonError::into_inner` recovery, so a poisoned lock no longer takes the daemon down mid-interaction. Settings sites route through an `Inner::lock_settings()` helper; the writer thread recovers and keeps saving instead of exiting its loop. Stale `# Panics` docs dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)