### PR TITLE
Fix plugin runtime gaps, enforce host-only actions, trim comment noise

### DIFF
--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -157,6 +157,19 @@ Plugins can `import` only from the `highbeam:*` scheme. `import 'fs'`,
 — no declaration required. See [sdk-reference.md](./sdk-reference.md) for
 per-function behavior, signatures, and examples.
 
+## Runtime globals
+
+The runtime is bare `QuickJS` plus exactly these host-installed globals — no
+other Web APIs exist (`fetch`, `URLSearchParams`, `crypto`, …):
+
+- `console.log/info/warn/error/debug` — see below.
+- `setTimeout` — awaitable; `clearTimeout` / `clearInterval` are no-ops.
+- `AbortController` / `AbortSignal` — the signal passed to `query()` is one.
+- `TextEncoder` / `TextDecoder` — UTF-8 only. Constructing `TextDecoder`
+  with any other encoding throws `RangeError`; invalid byte sequences
+  decode to U+FFFD. The main consumer is `fs.readCache`, which returns a
+  `Uint8Array`.
+
 ## Console + logging
 
 `console.log/info/warn/error/debug` from a plugin are captured to

--- a/docs/sdk-reference.md
+++ b/docs/sdk-reference.md
@@ -46,13 +46,17 @@ interface Result {
 }
 
 // Actions plugin code can construct. Host-only variants (quit,
-// openSettings, reloadPlugin, installPlugin, updatePlugins, noop) are
-// produced by the Core built-in only — never by JS plugins.
+// openSettings, reloadPlugin, installPlugin, updatePlugins) are produced
+// by the Core built-in only; the host rejects them in plugin-yielded
+// results and view dispatches.
 type Action =
     | { kind: 'openUrl'; url: string }
     | { kind: 'copy'; text: string }
     | { kind: 'exec'; cmd: string; args: readonly string[] }
-    | { kind: 'reveal'; path: string };
+    | { kind: 'reveal'; path: string }
+    | { kind: 'showView'; view: ViewDef; props: object; reset: boolean }
+    | { kind: 'closeView' }
+    | { kind: 'noop' };       // inert row — Enter just dismisses the launcher
 
 interface HttpResponse {
     status: number;
@@ -93,13 +97,12 @@ Notes:
 
 - `Result.key` is the frecency key for `(plugin_name, key)`. Don't fold the
   user's current input into it — that defeats frecency.
-- `Result.icon` is supported by the host wire shape (a
-  `data:image/<type>;base64,...` URI) but is not in the `Result` interface
-  exported from `types.d.ts`. Set it as a property anyway — the host reads
-  it. `plugins/app-launcher` does this.
+- `Result.icon` must be a `data:image/<type>;base64,...` URI. Bare
+  filesystem paths are treated as missing — pre-resolve via
+  `highbeam:icons.forPath(...)`.
 - `Action` has host-only variants (`quit`, `openSettings`, `reloadPlugin`,
-  `installPlugin`, `updatePlugins`, `noop`) emitted by the Core built-in.
-  Plugins don't construct them.
+  `installPlugin`, `updatePlugins`) emitted by the Core built-in. The host
+  rejects them in plugin-yielded results and view dispatches.
 
 ## `highbeam:actions`
 
@@ -284,11 +287,12 @@ want a side effect during `query()` (rare).
 Read files, walk directories, and use a plugin-scoped cache.
 
 ```js
-import { readDir, readFile, readText, readCache, writeCache } from 'highbeam:fs';
+import { readDir, readFile, readText, readCache, writeCache, basename } from 'highbeam:fs';
 ```
 
 **Capabilities:** `fs.read` for the file readers, `fs.cache` for the cache
-helpers. Both can be declared independently.
+helpers. Both can be declared independently. `basename` is a pure string
+helper available with either.
 
 Relative paths passed to `readDir` / `readFile` / `readText` resolve against
 the plugin's own directory, so `readText('./bundled.json')` works regardless
@@ -381,6 +385,19 @@ missing. Same naming rules as `readCache`. **Capability:** `fs.cache`.
 
 See `plugins/xkcd` for cache-backed iteration (build an index on
 first miss, serve subsequent queries from cache, refresh on TTL).
+
+### `basename(path: string): string`
+
+```js
+basename('/Applications/Firefox.app');  // 'Firefox.app'
+basename('/foo/bar/');                  // 'bar'
+basename('/');                          // ''
+```
+
+Final component of `path` after stripping trailing slashes. Empty string for
+the root and the empty path; `.` / `..` pass through as-is (matching Node's
+`path.posix.basename`). Pure string helper — works with either `fs.*`
+capability, no I/O.
 
 ## `highbeam:icons`
 

--- a/plugins/app-launcher/app-launcher.test.js
+++ b/plugins/app-launcher/app-launcher.test.js
@@ -181,7 +181,7 @@ describe('app-launcher Linux', () => {
 
         expect(results.length).toBeGreaterThan(0);
         const firefox = results.find((r) =>
-            /firefox/i.test(r.title.replace(/<[^>]+>/g, '')),
+            /firefox/i.test(r.title),
         );
         expect(firefox).toBeDefined();
         expect(firefox.key).toBe(`${LINUX_DIR}/firefox.desktop`);
@@ -198,7 +198,7 @@ describe('app-launcher Linux', () => {
             plugin.query('gimp', { aborted: false }),
         );
         const gimp = results.find((r) =>
-            /gimp/i.test(r.title.replace(/<[^>]+>/g, '')),
+            /gimp/i.test(r.title),
         );
         expect(gimp).toBeDefined();
         expect(gimp.icon).toBe(ICON_SENTINEL);
@@ -208,7 +208,7 @@ describe('app-launcher Linux', () => {
             plugin.query('firefox', { aborted: false }),
         );
         const firefox = fireResults.find((r) =>
-            /firefox/i.test(r.title.replace(/<[^>]+>/g, '')),
+            /firefox/i.test(r.title),
         );
         // Bare XDG names now resolve via the host's freedesktop-icons lookup;
         // the plugin hands the raw spec to `forPath` and lets the host walk

--- a/sdk/highbeam/fs.d.ts
+++ b/sdk/highbeam/fs.d.ts
@@ -69,3 +69,10 @@ export function writeCache(
     name: string,
     data: Uint8Array | string,
 ): Promise<void>;
+
+/**
+ * Final component of `path` after stripping trailing slashes. Empty string
+ * for the root and the empty path; `.` / `..` pass through as-is (matching
+ * Node's `path.posix.basename`). Pure string helper — no I/O, no extra cap.
+ */
+export function basename(path: string): string;

--- a/sdk/highbeam/fs.js
+++ b/sdk/highbeam/fs.js
@@ -11,3 +11,10 @@ export const readFile = vi.fn(async (_path, _opts) => new Uint8Array());
 export const readText = vi.fn(async (_path, _opts) => '');
 export const readCache = vi.fn(async (_name) => null);
 export const writeCache = vi.fn(async (_name, _data) => {});
+
+// Pure helper — real impl, mirroring the host's semantics.
+export const basename = (path) => {
+    const trimmed = String(path).replace(/\/+$/, '');
+    const idx = trimmed.lastIndexOf('/');
+    return idx < 0 ? trimmed : trimmed.slice(idx + 1);
+};

--- a/sdk/highbeam/types.d.ts
+++ b/sdk/highbeam/types.d.ts
@@ -12,6 +12,8 @@ export interface Result {
     key: string;
     title: string;
     subtitle?: string;
+    /** `data:image/...;base64,...` URI. Pre-resolve paths via `highbeam:icons`. */
+    icon?: string;
     /** Plugin's self-assessed score, 0..100. */
     weight?: number;
     /** Bypass frecency; sort to the top among other pinned results by weight. */
@@ -42,7 +44,9 @@ export type Action =
     | { kind: 'exec'; cmd: string; args: readonly string[] }
     | { kind: 'reveal'; path: string }
     | { kind: 'showView'; view: ViewDef; props: object; reset: boolean }
-    | { kind: 'closeView' };
+    | { kind: 'closeView' }
+    /** Inert row — Enter dismisses the launcher without doing anything. */
+    | { kind: 'noop' };
 
 /**
  * A view definition — passed to `showView()` from `highbeam:actions`.

--- a/src/app/callbacks.rs
+++ b/src/app/callbacks.rs
@@ -191,7 +191,6 @@ pub(super) fn wire_window_callbacks(
         );
     });
 
-    // Install — confirmed.
     let confirm_state_install = Arc::clone(&confirm_state);
     let host_view_for_confirm_install = Arc::clone(&host_view);
     let weak_confirm_install = window.as_weak();
@@ -205,7 +204,6 @@ pub(super) fn wire_window_callbacks(
         );
     });
 
-    // Install — cancelled.
     let confirm_state_cancel = confirm_state;
     let host_view_for_confirm_cancel = Arc::clone(&host_view);
     let weak_confirm_cancel = window.as_weak();
@@ -899,6 +897,14 @@ fn handle_view_dispatch(
             return;
         }
     };
+
+    // Must be rejected before execute() — Quit's effect (process::exit)
+    // happens inside execute, so the outcome-level guards below come too
+    // late for it.
+    if let Some(kind) = action.host_only_kind() {
+        tracing::warn!(%plugin, kind, "views: dispatch of host-only action ignored");
+        return;
+    }
     let outcome = match actions::execute(&action) {
         Ok(o) => o,
         Err(err) => {

--- a/src/app/host_view.rs
+++ b/src/app/host_view.rs
@@ -25,7 +25,6 @@ use crate::ui::ViewBlock;
 /// Shared slot. `None` when no host view is live.
 pub(super) type HostView = Arc<Mutex<Option<UpdateViewState>>>;
 
-/// Build a fresh empty slot for `AppState::start`.
 pub(super) fn new_slot() -> HostView {
     Arc::new(Mutex::new(None))
 }
@@ -46,7 +45,6 @@ impl UpdateViewState {
         }
     }
 
-    /// Index of the entry matching `name`, or `None` if absent.
     pub(super) fn position(&self, name: &str) -> Option<usize> {
         self.entries.iter().position(|e| e.name == name)
     }
@@ -67,7 +65,6 @@ pub(super) fn take_and_cancel(slot: &HostView) -> bool {
     true
 }
 
-/// One plugin's row in the update view.
 pub(super) struct UpdateEntry {
     pub name: String,
     pub local_version: String,
@@ -83,16 +80,22 @@ pub(super) enum EntryStatus {
     /// Local == remote (or remote isn't newer).
     UpToDate,
     /// Local plugin has no `manifestUrl`, can't auto-update.
-    Skipped { reason: String },
+    Skipped {
+        reason: String,
+    },
     /// Download + extract in flight.
-    Updating { new_version: String },
-    /// Install finished.
-    Updated { new_version: String },
+    Updating {
+        new_version: String,
+    },
+    Updated {
+        new_version: String,
+    },
     /// Check or install failed.
-    Failed { error: String },
+    Failed {
+        error: String,
+    },
 }
 
-/// End-of-run tallies.
 pub(super) struct UpdateSummary {
     pub updated: usize,
     pub up_to_date: usize,

--- a/src/app/install_flow.rs
+++ b/src/app/install_flow.rs
@@ -238,7 +238,6 @@ async fn request_confirmation(
     rx.await.unwrap_or(false)
 }
 
-/// Populate the `confirm-*` Slint properties from a [`ConfirmationSummary`].
 fn populate_confirm_view(window: &QueryWindow, summary: &ConfirmationSummary) {
     window.set_confirm_plugin_name(SharedString::from(summary.plugin_name.as_str()));
     window.set_confirm_display_name(SharedString::from(summary.display_name.as_str()));

--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -8,10 +8,8 @@ use tokio::sync::oneshot;
 use crate::plugins::manifest::Manifest;
 use crate::sdk::capability::explain_cap;
 
-/// One row in the capability list the confirmation view renders.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CapabilityEntry {
-    /// Raw capability string from the manifest.
     pub cap: String,
     /// Human-readable explanation — falls back to the raw cap when unknown.
     pub explanation: String,
@@ -30,20 +28,14 @@ impl CapabilityEntry {
     }
 }
 
-/// Everything the confirmation view needs to render itself.
 #[derive(Debug, Clone)]
 pub struct ConfirmationSummary {
     /// `display_name` when present, otherwise `name`.
     pub display_name: String,
-    /// Raw plugin name (manifest `name`).
     pub plugin_name: String,
-    /// Semver string, may be empty.
     pub version: String,
-    /// Optional human-readable description.
     pub description: String,
-    /// Source manifest URL.
     pub manifest_url: String,
-    /// Capability list to render.
     pub capabilities: Vec<CapabilityEntry>,
 }
 
@@ -74,7 +66,6 @@ impl ConfirmationSummary {
     }
 }
 
-/// Pending install/update waiting for the user's decision.
 pub struct PendingConfirmation {
     /// Send `true` → proceed, `false` → cancel.
     pub tx: oneshot::Sender<bool>,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -23,7 +23,6 @@ use crate::theme::Theme;
 use crate::window;
 
 pub struct Options {
-    /// Open the window immediately after the daemon starts.
     pub open_on_start: bool,
     /// Single-shot: skip the IPC socket bind and the hotkey listener, and
     /// quit the event loop on the first dismiss. The launcher behaves as

--- a/src/plugins/actions.rs
+++ b/src/plugins/actions.rs
@@ -45,9 +45,12 @@ pub enum ActionOutcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HostTask {
     /// `None` ⇒ reload every plugin; `Some(name)` ⇒ reload just that one.
-    Reload { name: Option<String> },
-    /// Install a plugin from the given manifest URL.
-    Install { url: String },
+    Reload {
+        name: Option<String>,
+    },
+    Install {
+        url: String,
+    },
 }
 
 /// Execute an action.

--- a/src/plugins/builtin/core.rs
+++ b/src/plugins/builtin/core.rs
@@ -13,9 +13,7 @@ pub const NAME: &str = "core";
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Verb the user types to install a plugin from a manifest URL.
 const INSTALL_VERB: &str = "install";
-/// Verb the user types to reload one or every loaded plugin.
 const RELOAD_VERB: &str = "reload";
 /// Verb the user types to check every loaded plugin against its remote
 /// manifest and re-install any with a newer version.

--- a/src/plugins/dispatch.rs
+++ b/src/plugins/dispatch.rs
@@ -19,7 +19,6 @@ use crate::plugins::runtime::LoadedPlugin;
 /// holding up an otherwise responsive UI.
 pub(crate) const MAX_DEBOUNCE_MS: u64 = 2000;
 
-/// One result, tagged with the plugin name that produced it.
 #[derive(Debug)]
 pub(crate) struct StreamedResult {
     pub plugin_name: String,

--- a/src/plugins/loader.rs
+++ b/src/plugins/loader.rs
@@ -29,7 +29,6 @@ pub struct LoadOutcome {
     pub reason: Option<LifecycleReason>,
 }
 
-/// Where to look for plugins.
 #[derive(Debug, Clone)]
 pub struct LoaderOptions {
     pub plugins_dir: PathBuf,

--- a/src/plugins/manifest.rs
+++ b/src/plugins/manifest.rs
@@ -22,7 +22,6 @@ const DEFAULT_DEFAULT_ENABLED: bool = true;
 /// at gating time.
 const KNOWN_PLATFORMS: &[&str] = &["macos", "linux"];
 
-/// Plugin metadata as it appears on disk.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Manifest {
@@ -247,7 +246,6 @@ impl Manifest {
         serde_json::from_slice(bytes)
     }
 
-    /// Resolve the plugin entry point relative to its directory.
     #[must_use]
     pub fn entry_path(&self, plugin_dir: &Path) -> PathBuf {
         plugin_dir.join(&self.entry)

--- a/src/plugins/registry.rs
+++ b/src/plugins/registry.rs
@@ -156,15 +156,16 @@ impl PluginRegistry {
     }
 }
 
-/// Reasons [`PluginRegistry::reload_one`] could fail.
 #[derive(Debug)]
 pub enum ReloadError {
-    /// The registry doesn't currently hold a plugin by that name.
     NotFound(String),
     /// The plugin dir was found but the new load failed (manifest parse,
     /// JS eval, etc.). The previous instance is kept in the registry so the
     /// user isn't left with a hole.
-    Failed { name: String, reason: String },
+    Failed {
+        name: String,
+        reason: String,
+    },
 }
 
 impl std::fmt::Display for ReloadError {

--- a/src/plugins/result.rs
+++ b/src/plugins/result.rs
@@ -12,7 +12,6 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-/// One result row.
 #[derive(Debug, Clone, Deserialize)]
 pub struct PluginResult {
     pub key: String,
@@ -118,6 +117,32 @@ pub enum Action {
     /// same thing.
     #[serde(rename = "closeView")]
     CloseView,
+}
+
+impl Action {
+    /// The wire `kind` when this variant is host-only (Core built-in only),
+    /// `None` for plugin-legal variants. The serde derive happily parses
+    /// every variant from plugin JSON, so the boundaries that accept
+    /// plugin-supplied actions (`stream_query`, view dispatch) reject these
+    /// explicitly — otherwise any plugin could yield `{"kind":"quit"}` and
+    /// kill the daemon on Enter.
+    #[must_use]
+    pub fn host_only_kind(&self) -> Option<&'static str> {
+        match self {
+            Self::Quit => Some("quit"),
+            Self::OpenSettings => Some("openSettings"),
+            Self::ReloadPlugin { .. } => Some("reloadPlugin"),
+            Self::InstallPlugin { .. } => Some("installPlugin"),
+            Self::UpdatePlugins => Some("updatePlugins"),
+            Self::OpenUrl { .. }
+            | Self::Copy { .. }
+            | Self::Exec { .. }
+            | Self::Reveal { .. }
+            | Self::Noop
+            | Self::ShowView { .. }
+            | Self::CloseView => None,
+        }
+    }
 }
 
 /// A result enriched with the plugin name that produced it. Two plugins

--- a/src/plugins/runtime.rs
+++ b/src/plugins/runtime.rs
@@ -31,7 +31,7 @@ use tokio_util::sync::CancellationToken;
 use crate::logging::LogErr;
 use crate::plugins::log::{LogLevel, PluginLog};
 use crate::plugins::manifest::Manifest;
-use crate::plugins::result::PluginResult;
+use crate::plugins::result::{Action, PluginResult};
 use crate::sdk::abort::{Abort, install_global_controller};
 use crate::sdk::actions::ActionsModule;
 use crate::sdk::capability;
@@ -44,6 +44,7 @@ use crate::sdk::r#match::MatchModule;
 use crate::sdk::platform::PlatformModule;
 use crate::sdk::settings::{self, SettingsModule};
 use crate::sdk::system;
+use crate::sdk::text_codec;
 use crate::sdk::timers;
 use crate::sdk::view::ViewModule;
 
@@ -72,7 +73,6 @@ const QUERY_GLOBAL: &str = "__highbeam_query";
 const ON_ENABLE_GLOBAL: &str = "__highbeam_on_enable";
 const ON_DISABLE_GLOBAL: &str = "__highbeam_on_disable";
 
-/// Which lifecycle hook to dispatch.
 #[derive(Debug, Clone, Copy)]
 pub enum HookKind {
     Enable,
@@ -141,9 +141,7 @@ pub struct LoadedPlugin {
     // Mirrors what the interrupt hook captures; we keep the Arc alive here.
     interrupt_flag: Arc<AtomicBool>,
     log: Arc<PluginLog>,
-    /// Whether the plugin exported an `onEnable` function.
     has_on_enable: bool,
-    /// Whether the plugin exported an `onDisable` function.
     has_on_disable: bool,
     /// Fires when this plugin is being torn down (e.g. registry swap, daemon
     /// shutdown). Lifecycle hook tasks observe this and forward it to the
@@ -151,7 +149,6 @@ pub struct LoadedPlugin {
     shutdown: CancellationToken,
 }
 
-/// Errors surfaced while loading or running a plugin.
 #[derive(Debug)]
 pub enum PluginError {
     Io(std::io::Error),
@@ -545,7 +542,6 @@ impl Drop for LoadedPlugin {
     }
 }
 
-/// Set of hook exports we found on the plugin's entry module.
 struct ExportFlags {
     has_on_enable: bool,
     has_on_disable: bool,
@@ -593,6 +589,10 @@ fn install_host_globals<S: std::hash::BuildHasher>(
     timers::install(ctx)
         .catch(ctx)
         .map_err(|err| PluginError::Js(format!("install setTimeout: {err}")))?;
+
+    text_codec::install(ctx)
+        .catch(ctx)
+        .map_err(|err| PluginError::Js(format!("install TextEncoder/TextDecoder: {err}")))?;
 
     // Per-plugin options bag; populated even when the plugin declared no
     // options so `get('anything')` is always callable and returns undefined.
@@ -727,7 +727,6 @@ async fn run_hook<'js>(
     result
 }
 
-/// Map a hook outcome to a `plugin.log` line.
 fn log_hook_outcome(
     log: &PluginLog,
     plugin_name: &str,
@@ -855,6 +854,16 @@ async fn stream_query<'js>(
             .map_err(|err| PluginError::Js(format!("JSON.stringify yielded value: {err}")))?;
         let parsed: PluginResult =
             serde_json::from_str(&json_str).map_err(|err| PluginError::InvalidResult(format!("{err}: {json_str}")))?;
+
+        let host_only = parsed
+            .action
+            .host_only_kind()
+            .or_else(|| parsed.alt_action.as_ref().and_then(Action::host_only_kind));
+        if let Some(kind) = host_only {
+            return Err(PluginError::InvalidResult(format!(
+                "action kind `{kind}` is host-only and not allowed from plugins"
+            )));
+        }
 
         if tx.send(parsed).is_err() {
             // Receiver dropped — treat as a cancel.

--- a/src/query_history/state.rs
+++ b/src/query_history/state.rs
@@ -22,9 +22,7 @@ pub(crate) struct QueryHistoryState {
 /// What the caller should do with the input field after a state transition.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum InputAction {
-    /// Leave the input text unchanged.
     NoChange,
-    /// Replace the input text with the contained string.
     SetTo(String),
 }
 

--- a/src/sdk/abort.rs
+++ b/src/sdk/abort.rs
@@ -64,7 +64,6 @@ impl Abort {
         &self.token
     }
 
-    /// Has this signal been aborted?
     #[must_use]
     pub fn is_aborted(&self) -> bool {
         self.token.is_cancelled()

--- a/src/sdk/fs.rs
+++ b/src/sdk/fs.rs
@@ -30,6 +30,7 @@ impl ModuleDef for FsModule {
         decl.declare("readText")?;
         decl.declare("readCache")?;
         decl.declare("writeCache")?;
+        decl.declare("basename")?;
         Ok(())
     }
 
@@ -53,8 +54,21 @@ impl ModuleDef for FsModule {
                 exports.export(export_name, cap_error_thrower(ctx, cap)?)?;
             }
         }
+
+        // Pure string helper — no I/O, so no per-function cap gate beyond
+        // the module-level fs.* requirement.
+        let basename_fn = Function::new(ctx.clone(), |path: String| basename(&path).to_owned())?;
+        exports.export("basename", basename_fn)?;
         Ok(())
     }
+}
+
+/// Final component of `path` after stripping trailing slashes. Empty string
+/// for the root and the empty path; `.` / `..` pass through as-is (matching
+/// Node's `path.posix.basename`).
+fn basename(path: &str) -> &str {
+    let trimmed = path.trim_end_matches('/');
+    trimmed.rfind('/').map_or(trimmed, |i| &trimmed[i + 1..])
 }
 
 /// Install per-plugin bindings. Must run BEFORE the plugin's entry module

--- a/src/sdk/js/text_codec.js
+++ b/src/sdk/js/text_codec.js
@@ -1,0 +1,40 @@
+// UTF-8-only TextEncoder / TextDecoder. Conversion happens host-side
+// (__highbeam_utf8_*); these classes are the spec-shaped wrappers.
+(() => {
+    if (globalThis.TextEncoder !== undefined) return;
+
+    class TextEncoder {
+        constructor() {
+            this.encoding = "utf-8";
+        }
+
+        encode(input = "") {
+            return __highbeam_utf8_encode(String(input));
+        }
+    }
+
+    class TextDecoder {
+        constructor(label = "utf-8") {
+            const enc = String(label).trim().toLowerCase();
+            if (enc !== "utf-8" && enc !== "utf8" && enc !== "unicode-1-1-utf-8") {
+                throw new RangeError(`TextDecoder: unsupported encoding ${label} (utf-8 only)`);
+            }
+            this.encoding = "utf-8";
+        }
+
+        decode(input) {
+            if (input === undefined) return "";
+            // Normalise the BufferSource shapes to the Uint8Array the host
+            // hook expects; anything else falls through and the host throws.
+            const bytes =
+                input instanceof Uint8Array ? input
+                : input instanceof ArrayBuffer ? new Uint8Array(input)
+                : ArrayBuffer.isView(input) ? new Uint8Array(input.buffer, input.byteOffset, input.byteLength)
+                : input;
+            return __highbeam_utf8_decode(bytes);
+        }
+    }
+
+    globalThis.TextEncoder = TextEncoder;
+    globalThis.TextDecoder = TextDecoder;
+})();

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -1,6 +1,6 @@
 //! Host implementations of the `highbeam:*` SDK modules. The cap gate lives
-//! in [`capability`]. `abort` and `timers` are polyfills installed on
-//! `globalThis` rather than `highbeam:*` modules.
+//! in [`capability`]. `abort`, `timers`, and `text_codec` are polyfills
+//! installed on `globalThis` rather than `highbeam:*` modules.
 
 pub mod abort;
 pub mod actions;
@@ -16,5 +16,6 @@ pub mod r#match;
 pub mod platform;
 pub mod settings;
 pub mod system;
+pub mod text_codec;
 pub mod timers;
 pub mod view;

--- a/src/sdk/text_codec.rs
+++ b/src/sdk/text_codec.rs
@@ -1,0 +1,45 @@
+//! UTF-8-only `TextEncoder` / `TextDecoder` polyfill.
+//!
+//! Raw `QuickJS` ships neither, but `fs.readCache` hands plugins a
+//! `Uint8Array` — without a decoder the bytes are a dead end. Conversion
+//! runs host-side (Rust strings are UTF-8 already; invalid sequences
+//! degrade to U+FFFD like a non-fatal spec decoder). The JS layer is a
+//! thin class wrapper; constructing `TextDecoder` with any label other
+//! than UTF-8 throws `RangeError`.
+
+use rquickjs::{Ctx, Error as JsError, Function, TypedArray, Value};
+
+use crate::sdk::errors::throw_named;
+
+const TEXT_CODEC_JS: &str = include_str!("js/text_codec.js");
+
+const ENCODE_GLOBAL: &str = "__highbeam_utf8_encode";
+const DECODE_GLOBAL: &str = "__highbeam_utf8_decode";
+
+/// Install `TextEncoder` / `TextDecoder` on the global object. Idempotent.
+///
+/// # Errors
+///
+/// Propagates JS errors from constructing the host functions or evaluating
+/// the wrapper script.
+pub fn install<'js>(ctx: &Ctx<'js>) -> Result<(), JsError> {
+    let encode = Function::new(ctx.clone(), |ctx: Ctx<'js>, text: String| {
+        TypedArray::new(ctx, text.into_bytes()).map(TypedArray::into_value)
+    })?;
+    ctx.globals().set(ENCODE_GLOBAL, encode)?;
+
+    let decode = Function::new(ctx.clone(), |ctx: Ctx<'js>, value: Value<'js>| {
+        let Ok(bytes) = TypedArray::<u8>::from_value(value) else {
+            return Err(throw_named(
+                &ctx,
+                "TypeError",
+                "TextDecoder.decode: expected a BufferSource",
+            ));
+        };
+        let slice: &[u8] = bytes.as_ref();
+        Ok(String::from_utf8_lossy(slice).into_owned())
+    })?;
+    ctx.globals().set(DECODE_GLOBAL, decode)?;
+
+    ctx.eval::<(), _>(TEXT_CODEC_JS)
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -64,7 +64,6 @@ pub struct Settings {
     plugins: HashMap<String, PluginSettings>,
 }
 
-/// Global launcher settings — anything that isn't per-plugin.
 #[derive(Debug, Clone, PartialEq)]
 pub struct GlobalSettings {
     /// Accelerator string parsed by `global_hotkey::HotKey::from_str`
@@ -136,7 +135,6 @@ pub fn normalize_alt_action_modifier(raw: &str) -> String {
         .map_or_else(|| DEFAULT_ALT_ACTION_MODIFIER.to_owned(), |c| (*c).to_owned())
 }
 
-/// Per-plugin settings as we store them.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct PluginSettings {
     pub enabled: bool,
@@ -423,7 +421,6 @@ impl Settings {
         slot.enabled = enabled;
     }
 
-    /// Last manifest version recorded for this plugin, if any.
     #[must_use]
     pub fn last_loaded_version(&self, name: &str) -> Option<&str> {
         self.plugins.get(name).and_then(|s| s.last_loaded_version.as_deref())
@@ -439,8 +436,6 @@ impl Settings {
         slot.last_loaded_version = version;
     }
 
-    /// Set one option value for one plugin. Other plugins' option bags are
-    /// untouched — scoping is per-plugin.
     pub fn set_plugin_option(&mut self, plugin: &str, key: &str, value: JsonValue) {
         let slot = self
             .plugins
@@ -458,13 +453,11 @@ impl Settings {
         out
     }
 
-    /// Read-only view of the global settings block.
     #[must_use]
     pub fn global(&self) -> &GlobalSettings {
         &self.global
     }
 
-    /// The configured maximum query-history entry count.
     #[must_use]
     pub fn query_history_max_entries(&self) -> usize {
         self.global.query_history_max_entries

--- a/src/settings_ui.rs
+++ b/src/settings_ui.rs
@@ -30,13 +30,10 @@ use crate::{os_appearance, window};
 struct PluginMetadata {
     /// Human-readable name — `display_name` when present, otherwise `name`.
     display_name: String,
-    /// Optional semver string, ready to render with a `v` prefix.
     version: Option<String>,
-    /// Optional human-readable description.
     description: Option<String>,
 }
 
-/// Extract display metadata from a manifest for the settings right pane.
 fn plugin_metadata(manifest: &Manifest) -> PluginMetadata {
     PluginMetadata {
         display_name: manifest.display_name.clone().unwrap_or_else(|| manifest.name.clone()),

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -19,7 +19,6 @@ use tokio_util::sync::CancellationToken;
 /// plugin can't grow the stack without bound.
 pub const STACK_CAP: usize = 16;
 
-/// One pushed view frame.
 #[derive(Debug)]
 pub struct ViewFrame {
     /// Producing plugin name. Used to route render/event messages back to
@@ -39,7 +38,6 @@ pub struct ViewFrame {
 }
 
 impl ViewFrame {
-    /// Build a frame with a fresh cancellation token.
     #[must_use]
     pub fn new(plugin_name: String, handle: u64, props: Value) -> Self {
         Self {
@@ -51,7 +49,6 @@ impl ViewFrame {
     }
 }
 
-/// LIFO stack of [`ViewFrame`]s.
 #[derive(Debug, Default)]
 pub struct ViewStack {
     frames: Vec<ViewFrame>,
@@ -116,13 +113,11 @@ impl ViewStack {
         popped
     }
 
-    /// Number of frames on the stack right now.
     #[must_use]
     pub fn depth(&self) -> usize {
         self.frames.len()
     }
 
-    /// Borrow the topmost frame, if any.
     #[must_use]
     pub fn top(&self) -> Option<&ViewFrame> {
         self.frames.last()

--- a/tests/plugin_runtime.rs
+++ b/tests/plugin_runtime.rs
@@ -57,6 +57,14 @@ export async function* query(input, signal) {
 }
 "#;
 
+/// Yields one valid row, then a row with a host-only action.
+const HOST_ONLY_ACTION_PLUGIN: &str = r#"
+export async function* query(input, _signal) {
+    yield { key: "ok", title: "fine", action: { kind: "copy", text: input } };
+    yield { key: "evil", title: "quit", action: { kind: "quit" } };
+}
+"#;
+
 fn write_plugin(dir: &std::path::Path, manifest_json: &str, source: &str) {
     fs::write(dir.join("manifest.json"), manifest_json).expect("write manifest");
     fs::write(dir.join("plugin.js"), source).expect("write plugin.js");
@@ -106,6 +114,30 @@ fn echo_plugin_yields_expected_result() {
         let mut rx = plugin.run_query_stream("", CancellationToken::new());
         let empty = drain(&mut rx).await;
         assert!(empty.is_empty());
+    });
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn host_only_action_kind_kills_the_stream() {
+    let dir = fresh_tmp("host-only-action");
+    write_plugin(
+        &dir,
+        r#"{"name":"host-only-action","entry":"plugin.js","timeoutMs":2000}"#,
+        HOST_ONLY_ACTION_PLUGIN,
+    );
+    let manifest = Manifest::parse(&fs::read(dir.join("manifest.json")).unwrap()).unwrap();
+
+    let runtime = rt();
+    runtime.block_on(async {
+        let plugin = LoadedPlugin::load(&dir, manifest).await.expect("load plugin");
+        let mut rx = plugin.run_query_stream("x", CancellationToken::new());
+        let results = drain(&mut rx).await;
+        // The valid row lands; the `quit` row is rejected as InvalidResult
+        // and closes the stream instead of reaching the dispatcher.
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].key, "ok");
     });
 
     let _ = fs::remove_dir_all(&dir);

--- a/tests/sdk_fs.rs
+++ b/tests/sdk_fs.rs
@@ -57,6 +57,33 @@ async fn run_script(can_read: bool, can_cache: bool, cache_dir: PathBuf, src: Ve
 }
 
 #[test]
+fn basename_strips_directories_and_trailing_slashes() {
+    let dir = fresh_tmp("basename");
+    let cache = dir.join("cache");
+    let rt = rt();
+    // Both caps false — basename is a pure helper and must work ungated.
+    let outcome = rt.block_on(run_script(
+        false,
+        false,
+        cache,
+        br"
+            import { basename } from 'highbeam:fs';
+            globalThis.__test = Promise.resolve([
+                basename('/foo/bar.txt'),
+                basename('/foo/bar/'),
+                basename('relative.md'),
+                basename('/'),
+                basename(''),
+                basename('..'),
+            ].join('|'));
+        "
+        .to_vec(),
+    ));
+    assert_eq!(outcome, "bar.txt|bar|relative.md|||..");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn read_text_without_cap_throws() {
     let dir = fresh_tmp("no-cap");
     let cache = dir.join("cache");

--- a/tests/sdk_shape.rs
+++ b/tests/sdk_shape.rs
@@ -22,7 +22,7 @@ fn expected_for(name: &str) -> &'static [&'static str] {
         "highbeam:actions" => &["openUrl", "copy", "exec", "reveal", "showView", "closeView"],
         "highbeam:http" => &["get", "post", "put", "patch", "delete"],
         "highbeam:clipboard" => &["read", "write"],
-        "highbeam:fs" => &["readDir", "readFile", "readText", "readCache", "writeCache"],
+        "highbeam:fs" => &["readDir", "readFile", "readText", "readCache", "writeCache", "basename"],
         "highbeam:icons" => &["forPath"],
         "highbeam:match" => &["fuzzy"],
         "highbeam:system" => &["exec", "applescript"],

--- a/tests/sdk_text_codec.rs
+++ b/tests/sdk_text_codec.rs
@@ -1,0 +1,111 @@
+//! Behavioural tests for the UTF-8 `TextEncoder` / `TextDecoder` polyfill.
+
+use rquickjs::{AsyncContext, AsyncRuntime, CatchResultExt, async_with};
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio rt")
+}
+
+fn eval_str(script: &str) -> String {
+    let rt = rt();
+    rt.block_on(async {
+        let async_rt = AsyncRuntime::new().expect("rt");
+        let ctx = AsyncContext::full(&async_rt).await.expect("ctx");
+        async_with!(ctx => |ctx| {
+            high_beam::sdk::text_codec::install(&ctx).catch(&ctx).expect("install");
+            ctx.eval::<String, _>(script).catch(&ctx).expect("eval")
+        })
+        .await
+    })
+}
+
+#[test]
+fn encode_decode_round_trips_multibyte() {
+    let out = eval_str(r#"new TextDecoder().decode(new TextEncoder().encode("héllo 🚀 ✓"))"#);
+    assert_eq!(out, "héllo 🚀 ✓");
+}
+
+#[test]
+fn decode_degrades_invalid_bytes_to_replacement_char() {
+    // Non-fatal spec decoders map invalid sequences to U+FFFD; the host
+    // side uses from_utf8_lossy which matches that.
+    let out = eval_str("new TextDecoder().decode(new Uint8Array([0xff, 0x68, 0x69]))");
+    assert_eq!(out, "\u{FFFD}hi");
+}
+
+#[test]
+fn decode_accepts_arraybuffer_and_offset_views() {
+    let out = eval_str(
+        r#"
+        const buf = new TextEncoder().encode("xxhi").buffer;
+        const whole = new TextDecoder().decode(buf);
+        const view = new TextDecoder().decode(new Uint8Array(buf, 2, 2));
+        `${whole}|${view}`
+        "#,
+    );
+    assert_eq!(out, "xxhi|hi");
+}
+
+#[test]
+fn decode_of_undefined_is_empty_string() {
+    let out = eval_str(r#"new TextDecoder().decode() === "" ? "ok" : "fail""#);
+    assert_eq!(out, "ok");
+}
+
+#[test]
+fn non_utf8_label_throws_range_error() {
+    let out = eval_str(
+        r#"
+        let result = "no throw";
+        try {
+            new TextDecoder("latin1");
+        } catch (e) {
+            result = e instanceof RangeError ? "RangeError" : `wrong type: ${e}`;
+        }
+        result
+        "#,
+    );
+    assert_eq!(out, "RangeError");
+}
+
+#[test]
+fn decode_of_non_buffer_throws_type_error() {
+    let out = eval_str(
+        r#"
+        let result = "no throw";
+        try {
+            new TextDecoder().decode("not bytes");
+        } catch (e) {
+            result = e.name;
+        }
+        result
+        "#,
+    );
+    assert_eq!(out, "TypeError");
+}
+
+#[test]
+fn encoding_property_reports_utf8() {
+    let out = eval_str(r#"`${new TextEncoder().encoding}|${new TextDecoder("UTF-8").encoding}`"#);
+    assert_eq!(out, "utf-8|utf-8");
+}
+
+#[test]
+fn install_is_idempotent() {
+    let rt = rt();
+    let out = rt.block_on(async {
+        let async_rt = AsyncRuntime::new().expect("rt");
+        let ctx = AsyncContext::full(&async_rt).await.expect("ctx");
+        async_with!(ctx => |ctx| {
+            high_beam::sdk::text_codec::install(&ctx).catch(&ctx).expect("first install");
+            ctx.eval::<(), _>("globalThis.__probe = TextDecoder").catch(&ctx).expect("stash");
+            high_beam::sdk::text_codec::install(&ctx).catch(&ctx).expect("second install");
+            ctx.eval::<bool, _>("globalThis.__probe === TextDecoder").catch(&ctx).expect("compare")
+        })
+        .await
+    });
+    assert!(out, "second install must not replace the classes");
+}

--- a/ui/confirm_view.slint
+++ b/ui/confirm_view.slint
@@ -20,7 +20,6 @@ export component ConfirmView {
     // 0 = Install button focused, 1 = Cancel button focused.
     in-out property <int> confirm-focus-index: 0;
 
-    // Theme tokens
     in property <color> foreground-color;
     in property <color> muted-color;
     in property <color> highlight-color;
@@ -29,7 +28,6 @@ export component ConfirmView {
     in property <length> font-size-title;
     in property <length> font-size-subtitle;
 
-    // Callbacks
     callback confirm-install();
     callback confirm-cancel();
 
@@ -39,7 +37,6 @@ export component ConfirmView {
     }
 
     VerticalLayout {
-        // Header bar.
         Rectangle {
             height: 48px;
             background: transparent;
@@ -62,13 +59,11 @@ export component ConfirmView {
             background: root.border-color;
         }
 
-        // Body: scrollable plugin info + capability list.
         ScrollView {
             VerticalLayout {
                 padding: 16px;
                 spacing: 10px;
 
-                // Plugin name + version.
                 HorizontalLayout {
                     spacing: 8px;
                     alignment: start;
@@ -86,7 +81,6 @@ export component ConfirmView {
                     }
                 }
 
-                // Description.
                 if root.confirm-description != "": Text {
                     text: root.confirm-description;
                     color: root.muted-color;
@@ -94,7 +88,6 @@ export component ConfirmView {
                     wrap: word-wrap;
                 }
 
-                // Source URL.
                 Text {
                     text: root.confirm-manifest-url;
                     color: root.muted-color;
@@ -102,14 +95,12 @@ export component ConfirmView {
                     overflow: elide;
                 }
 
-                // Capability list header.
                 if root.confirm-capabilities.length > 0: Text {
                     text: "Capabilities requested:";
                     color: root.foreground-color;
                     font-size: root.font-size-title;
                 }
 
-                // One row per capability.
                 for cap-row in confirm-capabilities: Rectangle {
                     height: 44px;
                     background: cap-row.is-new
@@ -197,7 +188,6 @@ export component ConfirmView {
                 spacing: 12px;
                 alignment: end;
 
-                // Cancel button.
                 TouchArea {
                     width: 90px;
                     height: 32px;
@@ -222,7 +212,6 @@ export component ConfirmView {
                     }
                 }
 
-                // Install button — receives initial focus.
                 TouchArea {
                     width: 90px;
                     height: 32px;

--- a/ui/launcher_view.slint
+++ b/ui/launcher_view.slint
@@ -13,7 +13,6 @@
 import { ResultRow } from "types.slint";
 
 export component LauncherView {
-    // Data
     in-out property <[ResultRow]> results: [];
     in-out property <int> selected-index: 0;
     in-out property <int> max-rows: 9;
@@ -24,7 +23,6 @@ export component LauncherView {
     // modifier will trigger right now.
     in property <bool> alt-modifier-active: false;
 
-    // Theme tokens
     in property <color> foreground-color;
     in property <color> muted-color;
     in property <color> selection-color;
@@ -68,7 +66,6 @@ export component LauncherView {
     }
 
     VerticalLayout {
-        // Input area
         Rectangle {
             height: 80px;
             input := TextInput {
@@ -179,13 +176,11 @@ export component LauncherView {
             }
         }
 
-        // Separator line — only visible when there are results.
         Rectangle {
             height: results.length > 0 ? 1px : 0;
             background: root.border-color;
         }
 
-        // Result rows
         Rectangle {
             height: rows-height;
             clip: true;

--- a/ui/query.slint
+++ b/ui/query.slint
@@ -49,7 +49,6 @@ export component QueryWindow inherits Window {
     in-out property <string> view-frame-title: "";
     in-out property <bool> view-has-title: false;
 
-    // Settings view state.
     in-out property <[PluginSlot]> plugin-slots: [];
     in-out property <int> selected-plugin-index: 0;
     in-out property <[PluginOption]> plugin-options: [];

--- a/ui/settings_view.slint
+++ b/ui/settings_view.slint
@@ -14,7 +14,6 @@ import { ThemedComboBox } from "themed_combobox.slint";
 import { PluginSlot, PluginOption } from "types.slint";
 
 export component SettingsView {
-    // Rail + plugin data
     in-out property <[PluginSlot]> plugin-slots: [];
     in-out property <int> selected-plugin-index: 0;
     in-out property <[PluginOption]> plugin-options: [];
@@ -23,7 +22,6 @@ export component SettingsView {
     in-out property <bool> showing-global: true;
     in-out property <int> rail-focus-index: 0;
 
-    // Global pane state
     in-out property <string> hotkey-value: "Shift+Space";
     in-out property <bool> capturing-hotkey: false;
     in-out property <string> alt-action-modifier: "Alt";
@@ -36,7 +34,6 @@ export component SettingsView {
     in property <[string]> theme-names: ["default"];
     in property <int> theme-index: 0;
 
-    // Theme tokens
     in property <color> background-color;
     in property <color> foreground-color;
     in property <color> muted-color;
@@ -72,7 +69,6 @@ export component SettingsView {
     }
 
     VerticalLayout {
-        // Header bar.
         Rectangle {
             height: 48px;
             background: transparent;
@@ -135,7 +131,6 @@ export component SettingsView {
             background: root.border-color;
         }
 
-        // Body: split into left rail (plugin list) + right pane (options).
         HorizontalLayout {
             spacing: 0px;
 
@@ -191,7 +186,6 @@ export component SettingsView {
                     ScrollView {
                         VerticalLayout {
                             spacing: 0px;
-                            // "Global" entry pinned at the top of the rail.
                             TouchArea {
                                 height: 44px;
                                 clicked => {
@@ -220,7 +214,6 @@ export component SettingsView {
                                     }
                                 }
                             }
-                            // Faint separator between Global and the plugin list.
                             Rectangle {
                                 height: 1px;
                                 background: root.border-color;
@@ -278,7 +271,6 @@ export component SettingsView {
                 }
             }
 
-            // Vertical divider.
             Rectangle {
                 width: 1px;
                 background: root.border-color;
@@ -365,7 +357,6 @@ export component SettingsView {
                             }
                         }
 
-                        // Window position group.
                         VerticalLayout {
                             spacing: 4px;
                             Text {
@@ -399,7 +390,6 @@ export component SettingsView {
                             }
                         }
 
-                        // Alt-action modifier group.
                         VerticalLayout {
                             spacing: 4px;
                             Text {
@@ -437,7 +427,6 @@ export component SettingsView {
                             }
                         }
 
-                        // Theme group: which theme + a manual reload.
                         VerticalLayout {
                             spacing: 4px;
                             Text {
@@ -493,7 +482,6 @@ export component SettingsView {
                             }
                         }
 
-                        // Theme mode group.
                         VerticalLayout {
                             spacing: 4px;
                             Text {
@@ -530,7 +518,6 @@ export component SettingsView {
                             }
                         }
 
-                        // Config files group.
                         VerticalLayout {
                             spacing: 4px;
                             Text {
@@ -571,7 +558,6 @@ export component SettingsView {
                     VerticalLayout {
                         padding: 16px;
                         spacing: 12px;
-                        // Selected-plugin header: name + optional version.
                         if plugin-slots.length > 0 && root.selected-plugin-index < plugin-slots.length: HorizontalLayout {
                             spacing: 8px;
                             alignment: space-between;
@@ -591,7 +577,6 @@ export component SettingsView {
                             }
                         }
 
-                        // Plugin description — only shown when present.
                         if root.selected-plugin-description != "": Text {
                             text: root.selected-plugin-description;
                             color: root.muted-color;


### PR DESCRIPTION
Comment and docblock sweep across the codebase, plus the bugs it shook out.

**Runtime fixes**

- `TextEncoder`/`TextDecoder` (UTF-8 only) are now installed as plugin-runtime globals (`src/sdk/text_codec.rs`). rquickjs 0.11 ships neither, while `fs.readCache` returns a `Uint8Array`: every cache hit in clipboard-history, currency-converter, obsidian, and xkcd threw `ReferenceError`, was caught, and read as a cache miss. clipboard-history capture was fully broken through its unguarded `new TextEncoder()` call.
- Host-only action kinds (`quit`, `openSettings`, `reloadPlugin`, `installPlugin`, `updatePlugins`) are rejected at both plugin boundaries: yielded results (surfaces as `InvalidResult` in plugin.log) and view dispatch. Previously a plugin could yield `{"kind":"quit"}` and exit the daemon on Enter; the view-dispatch path reached `process::exit` before its outcome guards ran.
- `highbeam:fs` gains `basename(path)`: pure string helper with identical semantics in the host and the vitest stub, no extra capability required.
- `types.d.ts` now declares `Result.icon` and the `noop` action kind. Both were host-supported all along; the docs even described the icon omission as a workaround. The stale notes are fixed and the full set of runtime globals is documented in plugin-authoring.md.

**Comment cleanup**

49 docblocks that restated the name or signature, 32 Slint section banners, and assorted narration comments removed. Surviving comments carry contracts, invariants, or platform rationale; `# Errors`/`# Panics` sections stay where lint-pedantic requires them.

Verified: `cargo fmt --check`, `just lint`, `just lint-pedantic` (0 warnings), 331 Rust tests, 168 plugin vitest tests, `cargo build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)