### PR TITLE
Fix codebase review findings: installer traversal, IPC robustness, stale view paints, plugin home dirs

### DIFF
--- a/plugins/app-launcher/app-launcher.test.js
+++ b/plugins/app-launcher/app-launcher.test.js
@@ -6,7 +6,8 @@ import { describe, expect, test, vi } from 'vitest';
 // safety. ESM namespaces are frozen, so replacing the module beats spyOn.
 vi.mock('node:os', () => {
     const platform = vi.fn(() => 'darwin');
-    return { default: { platform }, platform };
+    const homedir = vi.fn(() => '/Users/me');
+    return { default: { platform, homedir }, platform, homedir };
 });
 
 const ICON_SENTINEL = 'data:image/png;base64,SENTINEL';

--- a/plugins/app-launcher/manifest.json
+++ b/plugins/app-launcher/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "app-launcher",
   "displayName": "App Launcher",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Find and open installed applications",
   "debounceMs": 100,
   "timeoutMs": 800,
@@ -13,8 +13,7 @@
   "capabilities": [
     "actions",
     "fs.read",
-    "icons",
-    "system.exec"
+    "icons"
   ],
   "manifestUrl": "https://raw.githubusercontent.com/Mechazawa/High-Beam/master/plugins/app-launcher/manifest.json",
   "entryUrl": "https://raw.githubusercontent.com/Mechazawa/High-Beam/master/plugins/app-launcher/plugin.js"

--- a/plugins/app-launcher/plugin.js
+++ b/plugins/app-launcher/plugin.js
@@ -10,15 +10,13 @@ const MAC_APP_DIRECTORIES = [
     "/Applications",
     "/System/Applications",
     "/System/Library/CoreServices",
-    // QuickJS doesn't expose `$HOME`; the SDK silently skips unreadable dirs,
-    // so listing this unconditionally is cheap and safe.
-    "~/Applications",
+    `${os.homedir()}/Applications`,
 ];
 
 const LINUX_DESKTOP_DIRECTORIES = [
     "/usr/share/applications",
     "/usr/local/share/applications",
-    "~/.local/share/applications",
+    `${os.homedir()}/.local/share/applications`,
 ];
 
 const APP_EXT = ".app";

--- a/plugins/file-search/file-search.test.js
+++ b/plugins/file-search/file-search.test.js
@@ -4,7 +4,8 @@ import { describe, expect, test, vi } from 'vitest';
 // can flip the reported OS per test without touching the real platform.
 vi.mock('node:os', () => {
     const platform = vi.fn(() => 'darwin');
-    return { default: { platform }, platform };
+    const homedir = vi.fn(() => '/Users/me');
+    return { default: { platform, homedir }, platform, homedir };
 });
 
 const ICON_SENTINEL = 'data:image/png;base64,SENTINEL';
@@ -95,7 +96,7 @@ describe('file-search macOS', () => {
 
         expect(system.exec).toHaveBeenCalledWith(
             'mdfind',
-            ['-onlyin', '~', 'report'],
+            ['-onlyin', '/Users/me', 'report'],
             expect.objectContaining({}),
         );
         expect(results).toHaveLength(3);

--- a/plugins/file-search/manifest.json
+++ b/plugins/file-search/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "file-search",
   "displayName": "File Search",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Find files by name — type `find <query>`",
   "debounceMs": 150,
   "timeoutMs": 1500,

--- a/plugins/file-search/plugin.js
+++ b/plugins/file-search/plugin.js
@@ -39,13 +39,15 @@ function parseQuery(input) {
     return body;
 }
 
-// `mdfind -onlyin ~ "<query>"` scopes Spotlight to the user's home dir.
+// `mdfind -onlyin <home> "<query>"` scopes Spotlight to the user's home
+// dir. exec spawns without a shell, so `~` would reach mdfind as a literal
+// path and silently match nothing — pass the expanded home dir instead.
 // Output is newline-separated absolute paths; trailing newline is normal.
 // Empty stdout (no matches) is *not* an error — the exit code is still 0.
 async function runMdfind(query, signal) {
     const result = await exec(
         "mdfind",
-        ["-onlyin", "~", query],
+        ["-onlyin", os.homedir(), query],
         { signal },
     );
     if (result.code !== 0) return { paths: [], failed: true };

--- a/plugins/file-search/plugin.js
+++ b/plugins/file-search/plugin.js
@@ -13,6 +13,8 @@ import os from "node:os";
 const isMacOS = () => os.platform() === "darwin";
 const isLinux = () => os.platform() === "linux";
 
+const HOME = os.homedir();
+
 const RESULT_LIMIT = 20;
 // Below pinned things (which sit at 100) but above zero-weight stragglers,
 // so file matches don't fight calculator/dnd-style pinned plugins for the
@@ -47,7 +49,7 @@ function parseQuery(input) {
 async function runMdfind(query, signal) {
     const result = await exec(
         "mdfind",
-        ["-onlyin", os.homedir(), query],
+        ["-onlyin", HOME, query],
         { signal },
     );
     if (result.code !== 0) return { paths: [], failed: true };

--- a/plugins/prefpanes/manifest.json
+++ b/plugins/prefpanes/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "prefpanes",
   "displayName": "Preference Panes",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Quick-open macOS System Settings panes — type a pane name like 'Displays' or 'Network'",
   "debounceMs": 100,
   "timeoutMs": 600,

--- a/plugins/prefpanes/plugin.js
+++ b/plugins/prefpanes/plugin.js
@@ -9,7 +9,7 @@ const PREF_PANE_DIRECTORIES = [
     "/System/Library/PreferencePanes",
     "/Library/PreferencePanes",
     // User-installed panes; absent on a default install, readDir swallows the miss.
-    "~/Library/PreferencePanes",
+    `${os.homedir()}/Library/PreferencePanes`,
 ];
 
 const PANE_EXT = ".prefPane";

--- a/plugins/prefpanes/prefpanes.test.js
+++ b/plugins/prefpanes/prefpanes.test.js
@@ -4,7 +4,8 @@ import { describe, expect, test, vi } from 'vitest';
 // return value is reassignable per-test ('darwin' = macOS, anything else = not).
 vi.mock('node:os', () => {
     const platform = vi.fn(() => 'darwin');
-    return { default: { platform }, platform };
+    const homedir = vi.fn(() => '/Users/me');
+    return { default: { platform, homedir }, platform, homedir };
 });
 
 const ICON_SENTINEL = 'data:image/png;base64,PREFPANE';

--- a/src/app/callbacks.rs
+++ b/src/app/callbacks.rs
@@ -568,12 +568,14 @@ pub(super) fn build_view_bridge(
 ) -> Arc<RuntimeBridge> {
     let paint_tree = {
         let plugin = plugin_name.to_owned();
+        let view_stack = Arc::clone(&view_stack);
         let weak = slint_weak.clone();
         Box::new(move |handle: u64, tree_json: String| {
             let plugin = plugin.clone();
+            let view_stack = Arc::clone(&view_stack);
             let weak = weak.clone();
             slint::invoke_from_event_loop(move || {
-                paint_view_tree(&plugin, handle, &tree_json, &weak);
+                paint_view_tree(&plugin, handle, &tree_json, &view_stack, &weak);
             })
             .log_debug("views: paint_tree invoke_from_event_loop");
         })
@@ -684,7 +686,32 @@ fn paint_view_error(plugin: &str, handle: u64, message: &str, stack: &str, weak:
 /// non-rendering blocks (`button`, `input`, `textarea`, `image`, `row`,
 /// `divider`) come through as their `kind` only — Slint paints them as
 /// muted placeholders.
-fn paint_view_tree(plugin: &str, handle: u64, tree_json: &str, weak: &slint::Weak<QueryWindow>) {
+fn paint_view_tree(
+    plugin: &str,
+    handle: u64,
+    tree_json: &str,
+    view_stack: &Arc<Mutex<ViewStack>>,
+    weak: &slint::Weak<QueryWindow>,
+) {
+    // Paints are queued through invoke_from_event_loop, so one can land
+    // after its frame was already popped (Esc raced an in-flight render)
+    // — repainting here would resurrect a dead view with no frame left
+    // to pop. The same check keeps a buried frame's re-render from
+    // overwriting whatever is on top.
+    {
+        let Ok(stack) = view_stack.lock() else {
+            tracing::error!("views: stack lock poisoned; paint dropped");
+            return;
+        };
+        let is_top = stack
+            .top()
+            .is_some_and(|top| top.plugin_name == plugin && top.handle == handle);
+
+        if !is_top {
+            tracing::debug!(%plugin, handle, "views: paint for non-top frame dropped");
+            return;
+        }
+    }
     let parsed: serde_json::Value = match serde_json::from_str(tree_json) {
         Ok(v) => v,
         Err(err) => {

--- a/src/app/callbacks.rs
+++ b/src/app/callbacks.rs
@@ -703,11 +703,8 @@ fn paint_view_tree(
             tracing::error!("views: stack lock poisoned; paint dropped");
             return;
         };
-        let is_top = stack
-            .top()
-            .is_some_and(|top| top.plugin_name == plugin && top.handle == handle);
 
-        if !is_top {
+        if !stack.is_top(plugin, handle) {
             tracing::debug!(%plugin, handle, "views: paint for non-top frame dropped");
             return;
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -187,7 +187,7 @@ fn spawn_ipc_listener(
 ) -> io::Result<()> {
     let server = Server::bind(socket_path)?;
     thread::Builder::new().name("highbeam-ipc".into()).spawn(move || {
-        let result = server.run(move |cmd| match cmd {
+        server.run(move |cmd| match cmd {
             Command::Open { activation_token } => {
                 let weak = weak.clone();
                 let settings = settings.clone();
@@ -200,10 +200,6 @@ fn spawn_ipc_listener(
                 .log_debug("ipc: post Open to event loop");
             }
         });
-
-        if let Err(err) = result {
-            tracing::error!(%err, "ipc server exited");
-        }
     })?;
     Ok(())
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -122,11 +122,14 @@ impl Server {
     ///
     /// Each connection is read on its own short-lived thread so a client
     /// that connects and stalls can't wedge the accept loop — every later
-    /// `--open` would queue behind it forever. (A read timeout on the
-    /// accept thread would be simpler, but `SO_RCVTIMEO` proved unreliable
-    /// under load on macOS.) Per-connection failures are logged and
-    /// dropped; one bad client must not take the daemon's IPC down for
-    /// the rest of its life.
+    /// `--open` would queue behind it forever. A read timeout would be
+    /// simpler, but `send` is write-then-close, and on macOS `setsockopt`
+    /// fails with EINVAL once the peer has fully disconnected — even with
+    /// the command still readable in the buffer. Accept loses that race
+    /// whenever the machine is busy, so there is no safe place to set the
+    /// timeout. Per-connection failures are logged and dropped; one bad
+    /// client must not take the daemon's IPC down for the rest of its
+    /// life.
     pub(crate) fn run<F>(self, handler: F)
     where
         F: FnMut(Command) + Send + 'static,

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -4,11 +4,16 @@
 //! so a fixed read buffer is fine. Length-prefixed framing waits until we
 //! carry payloads bigger than a few bytes.
 
-use std::io::{self, BufRead, BufReader, Write};
+use std::io::{self, BufRead, BufReader, Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::thread;
 
 use crate::logging::LogErr;
+
+/// Commands are a few bytes; anything past this is not a real client.
+const MAX_COMMAND_BYTES: u64 = 4096;
 
 /// Commands accepted by the running daemon. Wire format is stable; do not
 /// rename without considering compat with running daemons.
@@ -114,25 +119,62 @@ impl Server {
     /// Block on the listener, calling `handler` for each parsed command.
     /// Intended pattern: dedicate a thread that owns the `Server` and
     /// forwards commands to the UI thread.
-    pub(crate) fn run<F>(self, mut handler: F) -> io::Result<()>
+    ///
+    /// Each connection is read on its own short-lived thread so a client
+    /// that connects and stalls can't wedge the accept loop — every later
+    /// `--open` would queue behind it forever. (A read timeout on the
+    /// accept thread would be simpler, but `SO_RCVTIMEO` proved unreliable
+    /// under load on macOS.) Per-connection failures are logged and
+    /// dropped; one bad client must not take the daemon's IPC down for
+    /// the rest of its life.
+    pub(crate) fn run<F>(self, handler: F)
     where
         F: FnMut(Command) + Send + 'static,
     {
+        let handler = Arc::new(Mutex::new(handler));
+
         for stream in self.listener.incoming() {
-            let stream = stream?;
-            let mut reader = BufReader::new(stream);
-            let mut line = String::new();
+            let stream = match stream {
+                Ok(s) => s,
+                Err(err) => {
+                    tracing::warn!(%err, "ipc: accept failed");
+                    continue;
+                }
+            };
+            let handler = Arc::clone(&handler);
+            let spawned = thread::Builder::new()
+                .name("highbeam-ipc-conn".into())
+                .spawn(move || handle_connection(stream, &handler));
 
-            if reader.read_line(&mut line)? == 0 {
-                continue;
-            }
-
-            match Command::parse(&line) {
-                Ok(cmd) => handler(cmd),
-                Err(err) => tracing::warn!(%err, "ipc: rejecting unknown command"),
+            if let Err(err) = spawned {
+                tracing::warn!(%err, "ipc: connection thread spawn failed");
             }
         }
-        Ok(())
+    }
+}
+
+fn handle_connection<F>(stream: UnixStream, handler: &Mutex<F>)
+where
+    F: FnMut(Command),
+{
+    let mut reader = BufReader::new(stream.take(MAX_COMMAND_BYTES));
+    let mut line = String::new();
+
+    match reader.read_line(&mut line) {
+        Ok(0) => return,
+        Ok(_) => {}
+        Err(err) => {
+            tracing::warn!(%err, "ipc: read failed");
+            return;
+        }
+    }
+
+    match Command::parse(&line) {
+        Ok(cmd) => match handler.lock() {
+            Ok(mut handler) => handler(cmd),
+            Err(err) => tracing::error!(%err, "ipc: handler mutex poisoned; command dropped"),
+        },
+        Err(err) => tracing::warn!(%err, "ipc: rejecting unknown command"),
     }
 }
 
@@ -200,7 +242,7 @@ mod tests {
 
         let (tx, rx) = mpsc::channel();
         let handle = thread::spawn(move || {
-            let _ = server.run(move |cmd| {
+            server.run(move |cmd| {
                 let _ = tx.send(cmd);
             });
         });

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -134,21 +134,14 @@ impl Server {
         let handler = Arc::new(Mutex::new(handler));
 
         for stream in self.listener.incoming() {
-            let stream = match stream {
-                Ok(s) => s,
-                Err(err) => {
-                    tracing::warn!(%err, "ipc: accept failed");
-                    continue;
-                }
+            let Some(stream) = stream.log_warn("ipc: accept failed") else {
+                continue;
             };
             let handler = Arc::clone(&handler);
-            let spawned = thread::Builder::new()
+            thread::Builder::new()
                 .name("highbeam-ipc-conn".into())
-                .spawn(move || handle_connection(stream, &handler));
-
-            if let Err(err) = spawned {
-                tracing::warn!(%err, "ipc: connection thread spawn failed");
-            }
+                .spawn(move || handle_connection(stream, &handler))
+                .log_warn("ipc: connection thread spawn failed");
         }
     }
 }

--- a/src/plugins/install.rs
+++ b/src/plugins/install.rs
@@ -218,12 +218,7 @@ fn require_installer_fields(manifest: &Manifest) -> Result<(), InstallError> {
 }
 
 fn is_single_normal_component(name: &str) -> bool {
-    let mut components = Path::new(name).components();
-
-    matches!(
-        (components.next(), components.next()),
-        (Some(std::path::Component::Normal(_)), None)
-    )
+    is_safe_relative_path(name) && Path::new(name).components().count() == 1
 }
 
 fn is_safe_relative_path(path: &str) -> bool {
@@ -466,6 +461,14 @@ pub fn find_payload_root(extracted_dir: &Path) -> PathBuf {
 ///
 /// Returns [`InstallError::Io`] on any filesystem step.
 pub fn move_into_plugins_dir(payload_root: &Path, plugins_dir: &Path, name: &str) -> Result<PathBuf, InstallError> {
+    // Backstop for the remove_dir_all below — the installer validates
+    // manifest names upstream, but this is a pub fn and the destination
+    // is destructive, so don't trust callers to have done so.
+    if !is_single_normal_component(name) {
+        return Err(InstallError::BadManifest(format!(
+            "name {name:?} must be a plain directory name (no separators or `..`)",
+        )));
+    }
     std::fs::create_dir_all(plugins_dir).map_err(|e| InstallError::Io(e.to_string()))?;
 
     let destination = plugins_dir.join(name);

--- a/src/plugins/install.rs
+++ b/src/plugins/install.rs
@@ -181,6 +181,26 @@ fn require_installer_fields(manifest: &Manifest) -> Result<(), InstallError> {
         return Err(InstallError::MissingField("name"));
     }
 
+    // `name` becomes `<plugins_dir>/<name>` and the destination is
+    // remove_dir_all'd before the move — a separator or `..` in a
+    // remotely-fetched manifest would delete and write outside the
+    // plugins dir.
+    if !is_single_normal_component(&manifest.name) {
+        return Err(InstallError::BadManifest(format!(
+            "name {:?} must be a plain directory name (no separators or `..`)",
+            manifest.name,
+        )));
+    }
+
+    // `entry` is written under the staging dir and read back relative to
+    // the installed plugin dir; both joins must stay inside it.
+    if !is_safe_relative_path(&manifest.entry) {
+        return Err(InstallError::BadManifest(format!(
+            "entry {:?} must be a relative path inside the plugin (no `..` or absolute components)",
+            manifest.entry,
+        )));
+    }
+
     if manifest.version.is_none() {
         return Err(InstallError::MissingField("version"));
     }
@@ -195,6 +215,22 @@ fn require_installer_fields(manifest: &Manifest) -> Result<(), InstallError> {
         (None, None) => Err(InstallError::MissingField("archiveUrl|entryUrl")),
         (Some(_), None) | (None, Some(_)) => Ok(()),
     }
+}
+
+fn is_single_normal_component(name: &str) -> bool {
+    let mut components = Path::new(name).components();
+
+    matches!(
+        (components.next(), components.next()),
+        (Some(std::path::Component::Normal(_)), None)
+    )
+}
+
+fn is_safe_relative_path(path: &str) -> bool {
+    !path.is_empty()
+        && Path::new(path)
+            .components()
+            .all(|c| matches!(c, std::path::Component::Normal(_)))
 }
 
 /// Download a single JS entry file (for the `entryUrl` install path). Caller
@@ -654,6 +690,46 @@ mod tests {
             }
             other => panic!("expected ConflictingFields, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn require_installer_fields_rejects_traversal_in_name() {
+        for name in ["../evil", "a/b", "/abs", "..", "."] {
+            let json = format!(r#"{{ "name": {name:?}, "version": "1.0.0", "entryUrl": "https://x/p.js" }}"#);
+            let m = Manifest::parse(json.as_bytes()).unwrap();
+
+            match require_installer_fields(&m) {
+                Err(InstallError::BadManifest(msg)) => {
+                    assert!(msg.contains("name"), "wrong message for {name:?}: {msg}");
+                }
+                other => panic!("expected BadManifest for name {name:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn require_installer_fields_rejects_traversal_in_entry() {
+        for entry in ["../../evil.js", "/abs.js", "a/../../b.js"] {
+            let json =
+                format!(r#"{{ "name": "x", "version": "1.0.0", "entry": {entry:?}, "entryUrl": "https://x/p.js" }}"#);
+            let m = Manifest::parse(json.as_bytes()).unwrap();
+
+            match require_installer_fields(&m) {
+                Err(InstallError::BadManifest(msg)) => {
+                    assert!(msg.contains("entry"), "wrong message for {entry:?}: {msg}");
+                }
+                other => panic!("expected BadManifest for entry {entry:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn require_installer_fields_accepts_subdir_entry() {
+        let m = Manifest::parse(
+            br#"{ "name": "x", "version": "1.0.0", "entry": "dist/plugin.js", "entryUrl": "https://x/p.js" }"#,
+        )
+        .unwrap();
+        require_installer_fields(&m).expect("subdir entry paths are valid");
     }
 
     #[test]

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -123,6 +123,13 @@ impl ViewStack {
         self.frames.last()
     }
 
+    /// Whether `(plugin, handle)` identifies the visible (top) frame.
+    #[must_use]
+    pub fn is_top(&self, plugin: &str, handle: u64) -> bool {
+        self.top()
+            .is_some_and(|top| top.plugin_name == plugin && top.handle == handle)
+    }
+
     /// Iterate every frame bottom-up.
     pub fn iter(&self) -> std::slice::Iter<'_, ViewFrame> {
         self.frames.iter()


### PR DESCRIPTION
Fixes from a full-codebase review.

- **Installer path traversal**: a remote manifest's `name`/`entry` reached `plugins_dir.join()` unvalidated, and the destination is `remove_dir_all`'d before the move, so a malicious manifest could delete and write outside the plugins dir. Both fields are now validated at the installer chokepoint, with a backstop inside `move_into_plugins_dir` itself.
- **IPC robustness**: a client that connected without sending wedged every later `--open` behind it, and a single per-connection error killed the IPC thread for the daemon's remaining lifetime. Connections now read on short-lived threads with a 4 KiB cap; failures are logged and dropped. A read timeout was the obvious alternative, but on macOS `setsockopt` fails with EINVAL once the peer has disconnected (and `send()` is write-then-close), verified with a standalone repro. The quirk is recorded in the `run()` doc comment.
- **Stale view paints**: a render racing Esc could land after its frame was popped and resurrect a dead view with no way to dismiss it. Paints now require their frame to be top of the stack (new `ViewStack::is_top`).
- **Plugin home-dir paths**: `~/Applications`, `~/.local/share/applications`, `~/Library/PreferencePanes` and `mdfind -onlyin ~` were all literal paths (nothing expands `~` without a shell), so user-level apps, prefpanes and macOS file search silently returned nothing. Switched to `os.homedir()`.
- **app-launcher manifest** drops its unused `system.exec` capability; the plugin only uses the capability-free `exec` action descriptor from `highbeam:actions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)